### PR TITLE
fix docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Instructions for installing MongoDB can be found on the [MongoDB website](https:
 
 For developers using Docker containers, the following docker command will quickly setup a container configured to use the default port:
 
-`docker run -d -p 27017:27017 --name="Test MongoDB" mongo:latest`
+`docker run -d -p 27017:27017 --name TestMongoDB mongo:latest`
 
 
 


### PR DESCRIPTION
Using the given command, docker throws an error because a name can't contain spaces. Is there some version which support spaces?

while the `--name="TestMongoDB"` would work too, the official doco passes params with the `--name TestMongoDB` style, so I adjusted it to that.

Thoughts?