### PR TITLE
Apply coding standards

### DIFF
--- a/src/NServiceBus.Storage.MongoDB.Tests/APIApprovals.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/APIApprovals.cs
@@ -1,16 +1,16 @@
-﻿using NUnit.Framework;
-using Particular.Approvals;
-using PublicApiGenerator;
-
-namespace NServiceBus.Storage.MongoDB.Tests
+﻿namespace NServiceBus.Storage.MongoDB.Tests
 {
+    using NUnit.Framework;
+    using Particular.Approvals;
+    using PublicApiGenerator;
+
     [TestFixture]
     public class APIApprovals
     {
         [Test]
         public void Approve()
         {
-            var publicApi = ApiGenerator.GeneratePublicApi(typeof(MongoPersistence).Assembly, excludeAttributes: new[] { "System.Runtime.Versioning.TargetFrameworkAttribute" });
+            var publicApi = ApiGenerator.GeneratePublicApi(typeof(MongoPersistence).Assembly, excludeAttributes: new[] {"System.Runtime.Versioning.TargetFrameworkAttribute"});
             Approver.Verify(publicApi);
         }
     }

--- a/src/NServiceBus.Storage.MongoDB.Tests/ClientProvider.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ClientProvider.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using MongoDB.Driver;
-
-namespace NServiceBus.Storage.MongoDB.Tests
+﻿namespace NServiceBus.Storage.MongoDB.Tests
 {
+    using System;
+    using global::MongoDB.Driver;
+
     static class ClientProvider
     {
-        static IMongoClient client;
-
         public static IMongoClient Client
         {
             get
@@ -21,5 +19,7 @@ namespace NServiceBus.Storage.MongoDB.Tests
                 return client;
             }
         }
+
+        static IMongoClient client;
     }
 }

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/IPersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/IPersistenceTestsConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿// ReSharper disable UnusedMemberInSuper.Global
+
 namespace NServiceBus.Persistence.ComponentTests
 {
     using System;

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/OutboxStorageTests.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/OutboxStorageTests.cs
@@ -9,8 +9,6 @@
     [TestFixture]
     class OutboxStorageTests
     {
-        PersistenceTestsConfiguration configuration;
-
         [OneTimeSetUp]
         public async Task OneTimeSetUp()
         {
@@ -34,7 +32,7 @@
 
             var messageId = Guid.NewGuid().ToString();
 
-            var messageToStore = new OutboxMessage(messageId, new[] { new TransportOperation("x", null, null, null) });
+            var messageToStore = new OutboxMessage(messageId, new[] {new TransportOperation("x", null, null, null)});
             using (var transaction = await storage.BeginTransaction(ctx))
             {
                 await storage.Store(messageToStore, transaction, ctx);
@@ -59,7 +57,7 @@
 
             var messageId = Guid.NewGuid().ToString();
 
-            var messageToStore = new OutboxMessage(messageId, new[] { new TransportOperation("x", null, null, null) });
+            var messageToStore = new OutboxMessage(messageId, new[] {new TransportOperation("x", null, null, null)});
 
             using (var transaction = await storage.BeginTransaction(ctx))
             {
@@ -122,7 +120,7 @@
 
             using (var transaction = await storage.BeginTransaction(ctx))
             {
-                var messageToStore = new OutboxMessage(messageId, new[] { new TransportOperation("x", null, null, null) });
+                var messageToStore = new OutboxMessage(messageId, new[] {new TransportOperation("x", null, null, null)});
                 await storage.Store(messageToStore, transaction, ctx);
 
                 // do not commit
@@ -144,7 +142,7 @@
 
             using (var transaction = await storage.BeginTransaction(ctx))
             {
-                var messageToStore = new OutboxMessage(messageId, new[] { new TransportOperation("x", null, null, null) });
+                var messageToStore = new OutboxMessage(messageId, new[] {new TransportOperation("x", null, null, null)});
                 await storage.Store(messageToStore, transaction, ctx);
 
                 await transaction.Commit();
@@ -154,5 +152,6 @@
             Assert.NotNull(message);
         }
 
+        PersistenceTestsConfiguration configuration;
     }
 }

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/PersistenceTestsConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿// ReSharper disable AutoPropertyCanBeMadeGetOnly.Global
+
 namespace NServiceBus.Persistence.ComponentTests
 {
     using System;
@@ -15,19 +16,20 @@ namespace NServiceBus.Persistence.ComponentTests
 
         public SagaMetadataCollection SagaMetadataCollection
         {
-            get{
+            get
+            {
                 if (sagaMetadataCollection == null)
                 {
                     var sagaTypes = Assembly.GetExecutingAssembly().GetTypes().Where(t => typeof(Saga).IsAssignableFrom(t) || typeof(IFindSagas<>).IsAssignableFrom(t) || typeof(IFinder).IsAssignableFrom(t)).ToArray();
                     sagaMetadataCollection = new SagaMetadataCollection();
                     sagaMetadataCollection.Initialize(sagaTypes);
                 }
+
                 return sagaMetadataCollection;
             }
             set { sagaMetadataCollection = value; }
         }
 
         SagaMetadataCollection sagaMetadataCollection;
-
     }
 }

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/AnotherSagaWithoutCorrelationProperty.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/AnotherSagaWithoutCorrelationProperty.cs
@@ -5,7 +5,7 @@ namespace NServiceBus.Persistence.ComponentTests
     using Extensibility;
     using Sagas;
 
-    class AnotherSagaWithoutCorrelationProperty : Saga<AnotherSagaWithoutCorrelationPropertyData>, 
+    class AnotherSagaWithoutCorrelationProperty : Saga<AnotherSagaWithoutCorrelationPropertyData>,
         IAmStartedByMessages<AnotherSagaWithoutCorrelationPropertyStartingMessage>
     {
         public Task Handle(AnotherSagaWithoutCorrelationPropertyStartingMessage message, IMessageHandlerContext context)

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/CombGuid.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/CombGuid.cs
@@ -26,7 +26,7 @@
             // Convert to a byte array
             // Note that SQL Server is accurate to 1/300th of a millisecond so we divide by 3.333333
             var daysArray = BitConverter.GetBytes(days.Days);
-            var millisecondArray = BitConverter.GetBytes((long) (timeOfDay.TotalMilliseconds/3.333333));
+            var millisecondArray = BitConverter.GetBytes((long)(timeOfDay.TotalMilliseconds / 3.333333));
 
             // Reverse the bytes to match SQL Servers ordering
             Array.Reverse(daysArray);

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/SagaPersisterTests.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/SagaPersisterTests.cs
@@ -21,8 +21,6 @@
 
     public class SagaPersisterTests
     {
-        protected PersistenceTestsConfiguration configuration;
-
         [OneTimeSetUp]
         public async Task OneTimeSetUp()
         {
@@ -66,6 +64,7 @@
                 await persister.Complete(sagaData, completeSession, context);
                 await completeSession.CompleteAsync();
             }
+
             return sagaData;
         }
 
@@ -87,6 +86,7 @@
                 await persister.Update(sagaData, completeSession, context);
                 await completeSession.CompleteAsync();
             }
+
             return sagaData;
         }
 
@@ -109,12 +109,13 @@
                 await persister.Update(sagaData, completeSession, context);
                 await completeSession.CompleteAsync();
             }
+
             return sagaData;
         }
 
         protected async Task<TSagaData> GetByCorrelationPropertyAndComplete<TSaga, TSagaData>(string correlatedPropertyName, object correlationPropertyData)
-           where TSaga : Saga<TSagaData>, new()
-           where TSagaData : class, IContainSagaData, new()
+            where TSaga : Saga<TSagaData>, new()
+            where TSagaData : class, IContainSagaData, new()
         {
             var context = configuration.GetContextBagForSagaStorage();
             TSagaData sagaData;
@@ -129,12 +130,13 @@
                 await persister.Complete(sagaData, completeSession, context);
                 await completeSession.CompleteAsync();
             }
+
             return sagaData;
         }
 
         protected async Task<TSagaData> GetByCorrelationProperty<TSaga, TSagaData>(string correlatedPropertyName, object correlationPropertyData)
-           where TSaga : Saga<TSagaData>, new()
-           where TSagaData : class, IContainSagaData, new()
+            where TSaga : Saga<TSagaData>, new()
+            where TSagaData : class, IContainSagaData, new()
         {
             var context = configuration.GetContextBagForSagaStorage();
             TSagaData sagaData;
@@ -148,6 +150,7 @@
 
                 await completeSession.CompleteAsync();
             }
+
             return sagaData;
         }
 
@@ -164,6 +167,7 @@
 
                 await readSession.CompleteAsync();
             }
+
             return sagaData;
         }
 
@@ -187,6 +191,7 @@
             {
                 sagaData.Id = configuration.SagaIdGenerator.Generate(new SagaIdGeneratorContext(correlationProperty, sagaMetadata, context));
             }
+
             sagaInstance.AttachNewEntity(sagaData);
             context.Set(sagaInstance);
 
@@ -194,7 +199,7 @@
         }
 
         protected void SetActiveSagaInstanceForGet<TSaga, TSagaData>(ContextBag context, TSagaData sagaData, params Type[] availableTypes)
-            where TSaga : Saga<TSagaData>, new ()
+            where TSaga : Saga<TSagaData>, new()
             where TSagaData : class, IContainSagaData, new()
         {
             var sagaMetadata = configuration.SagaMetadataCollection.FindByEntity(typeof(TSagaData));
@@ -203,5 +208,7 @@
             sagaInstance.AttachNewEntity(sagaData);
             context.Set(sagaInstance);
         }
+
+        protected PersistenceTestsConfiguration configuration;
     }
 }

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/SagaWithCorrelationPropertyData.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/SagaWithCorrelationPropertyData.cs
@@ -15,6 +15,7 @@ namespace NServiceBus.Persistence.ComponentTests
             mapper.ConfigureMapping<SagaCorrelationPropertyStartingMessage>(m => m.CorrelatedProperty).ToSaga(s => s.CorrelatedProperty);
         }
     }
+
     public class SagaWithCorrelationPropertyData : ContainSagaData
     {
         public string CorrelatedProperty { get; set; }

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/SagaWithoutCorrelationPropertyData.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/SagaWithoutCorrelationPropertyData.cs
@@ -5,7 +5,7 @@
     using Extensibility;
     using Sagas;
 
-    public class SagaWithoutCorrelationProperty : Saga<SagaWithoutCorrelationPropertyData>, 
+    public class SagaWithoutCorrelationProperty : Saga<SagaWithoutCorrelationPropertyData>,
         IAmStartedByMessages<SagaWithoutCorrelationPropertyStartingMessage>
     {
         public Task Handle(SagaWithoutCorrelationPropertyStartingMessage message, IMessageHandlerContext context)

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_completing_a_saga_loaded_by_id.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_completing_a_saga_loaded_by_id.cs
@@ -12,7 +12,7 @@
         {
             var correlationPropertyData = Guid.NewGuid().ToString();
 
-            var saga = new TestSagaData { SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
+            var saga = new TestSagaData {SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow};
 
             await SaveSaga(saga);
 

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_completing_a_saga_with_correlation_property.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_completing_a_saga_with_correlation_property.cs
@@ -12,7 +12,7 @@
         {
             var correlationPropertyData = Guid.NewGuid().ToString();
 
-            var saga = new SagaWithCorrelationPropertyData { CorrelatedProperty = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
+            var saga = new SagaWithCorrelationPropertyData {CorrelatedProperty = correlationPropertyData, DateTimeProperty = DateTime.UtcNow};
 
             await SaveSaga(saga);
 

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_completing_a_saga_with_no_defined_correlation_property.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_completing_a_saga_with_no_defined_correlation_property.cs
@@ -19,7 +19,7 @@
 
             var propertyData = Guid.NewGuid().ToString();
 
-            var sagaData = new SagaWithoutCorrelationPropertyData { FoundByFinderProperty = propertyData, DateTimeProperty = DateTime.UtcNow };
+            var sagaData = new SagaWithoutCorrelationPropertyData {FoundByFinderProperty = propertyData, DateTimeProperty = DateTime.UtcNow};
 
             var finder = typeof(CustomFinder);
 

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
@@ -21,7 +21,7 @@ namespace NServiceBus.Persistence.ComponentTests
             Guid generatedSagaId;
             using (var session = await configuration.SynchronizedStorage.OpenSession(savingContextBag))
             {
-                var sagaData = new TestSagaData { SomeId = correlationPropertData };
+                var sagaData = new TestSagaData {SomeId = correlationPropertData};
                 SetActiveSagaInstanceForSave(savingContextBag, new TestSaga(), sagaData);
                 generatedSagaId = sagaData.Id;
 
@@ -45,11 +45,11 @@ namespace NServiceBus.Persistence.ComponentTests
                         var enlistedContextBag = configuration.GetContextBagForSagaStorage();
                         var enlistedSession = await storageAdapter.TryAdapt(transportTransaction, enlistedContextBag);
 
-                        SetActiveSagaInstanceForGet<TestSaga,TestSagaData>(unenlistedContextBag, new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertData });
+                        SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(unenlistedContextBag, new TestSagaData {Id = generatedSagaId, SomeId = correlationPropertData});
                         var unenlistedRecord = await persister.Get<TestSagaData>(generatedSagaId, unenlistedSession, unenlistedContextBag);
                         SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(unenlistedContextBag, unenlistedRecord);
 
-                        SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(enlistedContextBag, new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertData });
+                        SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(enlistedContextBag, new TestSagaData {Id = generatedSagaId, SomeId = correlationPropertData});
                         var enlistedRecord = await persister.Get<TestSagaData>("Id", generatedSagaId, enlistedSession, enlistedContextBag);
                         SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(enlistedContextBag, enlistedRecord);
 
@@ -66,8 +66,6 @@ namespace NServiceBus.Persistence.ComponentTests
 
         class EnlistmentWhichEnforcesDtcEscalation : IEnlistmentNotification
         {
-            public static readonly Guid Id = Guid.NewGuid();
-
             public void Prepare(PreparingEnlistment preparingEnlistment)
             {
                 preparingEnlistment.Prepared();
@@ -87,6 +85,8 @@ namespace NServiceBus.Persistence.ComponentTests
             {
                 enlistment.Done();
             }
+
+            public static readonly Guid Id = Guid.NewGuid();
         }
     }
 }

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_complex_types.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_complex_types.cs
@@ -6,13 +6,13 @@
     using NUnit.Framework;
 
     [TestFixture]
-    public class When_persisting_a_saga_with_complex_types : SagaPersisterTests<SagaWithComplexType,SagaWithComplexTypeEntity>
+    public class When_persisting_a_saga_with_complex_types : SagaPersisterTests<SagaWithComplexType, SagaWithComplexTypeEntity>
     {
         [Test]
         public async Task It_should_get_deep_copy()
         {
             var correlationPropertyData = Guid.NewGuid().ToString();
-            var sagaData = new SagaWithComplexTypeEntity { Ints = new List<int> { 1, 2 }, CorrelationProperty = correlationPropertyData };
+            var sagaData = new SagaWithComplexTypeEntity {Ints = new List<int> {1, 2}, CorrelationProperty = correlationPropertyData};
 
             await SaveSaga(sagaData);
 

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_no_defined_unique_property.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_no_defined_unique_property.cs
@@ -13,7 +13,7 @@
             configuration.RequiresFindersSupport();
 
             var propertyData = Guid.NewGuid().ToString();
-            var sagaData = new SagaWithoutCorrelationPropertyData { FoundByFinderProperty = propertyData, DateTimeProperty = DateTime.UtcNow };
+            var sagaData = new SagaWithoutCorrelationPropertyData {FoundByFinderProperty = propertyData, DateTimeProperty = DateTime.UtcNow};
 
             var finder = typeof(CustomFinder);
 

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_the_same_unique_property_as_a_completed_saga.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_the_same_unique_property_as_a_completed_saga.cs
@@ -11,9 +11,9 @@
         public async Task It_should_persist_successfully()
         {
             var correlationPropertyData = Guid.NewGuid().ToString();
-            var saga1 = new SagaWithCorrelationPropertyData { CorrelatedProperty = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
-            var saga2 = new SagaWithCorrelationPropertyData { CorrelatedProperty = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
-            var saga3 = new SagaWithCorrelationPropertyData { CorrelatedProperty = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
+            var saga1 = new SagaWithCorrelationPropertyData {CorrelatedProperty = correlationPropertyData, DateTimeProperty = DateTime.UtcNow};
+            var saga2 = new SagaWithCorrelationPropertyData {CorrelatedProperty = correlationPropertyData, DateTimeProperty = DateTime.UtcNow};
+            var saga3 = new SagaWithCorrelationPropertyData {CorrelatedProperty = correlationPropertyData, DateTimeProperty = DateTime.UtcNow};
 
             await SaveSaga(saga1);
             await GetByIdAndComplete(saga1.Id);

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_the_same_unique_property_as_another_saga.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_the_same_unique_property_as_another_saga.cs
@@ -5,7 +5,7 @@
     using NUnit.Framework;
 
     [TestFixture]
-    public class When_persisting_a_saga_with_the_same_unique_property_as_another_saga: SagaPersisterTests
+    public class When_persisting_a_saga_with_the_same_unique_property_as_another_saga : SagaPersisterTests
     {
         [Test]
         public async Task It_should_enforce_uniqueness()

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_persisting_different_sagas_with_unique_properties.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_persisting_different_sagas_with_unique_properties.cs
@@ -18,7 +18,7 @@
             };
             var saga2 = new AnotherSagaWithCorrelatedPropertyData
             {
-                CorrelatedProperty = correlationPropertyData,
+                CorrelatedProperty = correlationPropertyData
             };
 
             var persister = configuration.SagaStorage;

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_persisting_the_same_saga_twice_in_two_sessions_on_the_same_thread.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_persisting_the_same_saga_twice_in_two_sessions_on_the_same_thread.cs
@@ -1,4 +1,5 @@
 // ReSharper disable AccessToDisposedClosure
+
 namespace NServiceBus.Persistence.ComponentTests
 {
     using System;
@@ -13,7 +14,7 @@ namespace NServiceBus.Persistence.ComponentTests
         public async Task Save_process_is_repeatable()
         {
             var correlationPropertyData = Guid.NewGuid().ToString();
-            var saga = new TestSagaData { SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
+            var saga = new TestSagaData {SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow};
 
             var persister = configuration.SagaStorage;
             var insertContextBag = configuration.GetContextBagForSagaStorage();

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_retrieving_same_saga_on_different_threads.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_retrieving_same_saga_on_different_threads.cs
@@ -1,4 +1,5 @@
 // ReSharper disable AccessToDisposedClosure
+
 namespace NServiceBus.Persistence.ComponentTests
 {
     using System;
@@ -19,7 +20,7 @@ namespace NServiceBus.Persistence.ComponentTests
             Guid generatedSagaId;
             using (var insertSession = await configuration.SynchronizedStorage.OpenSession(insertContextBag))
             {
-                var sagaData = new TestSagaData { SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
+                var sagaData = new TestSagaData {SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow};
                 var correlationProperty = SetActiveSagaInstanceForSave(insertContextBag, new TestSaga(), sagaData);
                 generatedSagaId = sagaData.Id;
 
@@ -35,7 +36,7 @@ namespace NServiceBus.Persistence.ComponentTests
                 var winningContext = configuration.GetContextBagForSagaStorage();
                 using (var winningSaveSession = await configuration.SynchronizedStorage.OpenSession(winningContext))
                 {
-                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertyData });
+                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, new TestSagaData {Id = generatedSagaId, SomeId = correlationPropertyData});
                     var record = await persister.Get<TestSagaData>(generatedSagaId, winningSaveSession, winningContext);
                     SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, record);
 
@@ -55,7 +56,7 @@ namespace NServiceBus.Persistence.ComponentTests
                 var losingSaveContext = configuration.GetContextBagForSagaStorage();
                 using (var losingSaveSession = await configuration.SynchronizedStorage.OpenSession(losingSaveContext))
                 {
-                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingSaveContext, new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertyData });
+                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingSaveContext, new TestSagaData {Id = generatedSagaId, SomeId = correlationPropertyData});
                     var staleRecord = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession, losingSaveContext);
                     SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingSaveContext, staleRecord);
 

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_retrieving_same_saga_on_the_same_thread.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_retrieving_same_saga_on_the_same_thread.cs
@@ -1,4 +1,5 @@
 ﻿// ReSharper disable AccessToDisposedClosure
+
 namespace NServiceBus.Persistence.ComponentTests
 {
     using System;
@@ -19,7 +20,7 @@ namespace NServiceBus.Persistence.ComponentTests
             Guid generatedSagaId;
             using (var insertSession = await configuration.SynchronizedStorage.OpenSession(insertContextBag))
             {
-                var sagaData = new TestSagaData { SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
+                var sagaData = new TestSagaData {SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow};
                 var correlationProperty = SetActiveSagaInstanceForSave(insertContextBag, new TestSaga(), sagaData);
                 generatedSagaId = sagaData.Id;
 
@@ -35,13 +36,13 @@ namespace NServiceBus.Persistence.ComponentTests
             var winningSaveSession = await configuration.SynchronizedStorage.OpenSession(winningContext);
             try
             {
-                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertyData });
+                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, new TestSagaData {Id = generatedSagaId, SomeId = correlationPropertyData});
                 var record = await persister.Get<TestSagaData>(generatedSagaId, winningSaveSession, winningContext);
                 SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, record);
 
                 losingContext = configuration.GetContextBagForSagaStorage();
                 losingSaveSession = await configuration.SynchronizedStorage.OpenSession(losingContext);
-                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext, new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertyData });
+                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext, new TestSagaData {Id = generatedSagaId, SomeId = correlationPropertyData});
                 staleRecord = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession, losingContext);
                 SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext, staleRecord);
 

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_retrieving_the_same_saga_twice.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_retrieving_the_same_saga_twice.cs
@@ -11,7 +11,7 @@ namespace NServiceBus.Persistence.ComponentTests
         public async Task Get_returns_different_instance_of_saga_data()
         {
             var correlationPropertyData = Guid.NewGuid().ToString();
-            var saga = new TestSagaData { SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
+            var saga = new TestSagaData {SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow};
 
             await SaveSaga(saga);
 

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_updating_a_saga_with_no_defined_unique_property.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_updating_a_saga_with_no_defined_unique_property.cs
@@ -22,12 +22,12 @@
             var finder = typeof(CustomFinder);
 
             await SaveSaga(sagaData, finder);
-            
+
             var updateValue = Guid.NewGuid().ToString();
             await GetByIdAndUpdate(sagaData.Id, saga => { saga.FoundByFinderProperty = updateValue; }, finder);
 
             var result = await GetById(sagaData.Id, finder);
-            
+
             Assert.That(result, Is.Not.Null);
             Assert.That(result.FoundByFinderProperty, Is.EqualTo(updateValue));
         }

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_worker_tries_to_complete_saga_update_by_another.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_worker_tries_to_complete_saga_update_by_another.cs
@@ -1,4 +1,5 @@
 ﻿// ReSharper disable AccessToDisposedClosure
+
 namespace NServiceBus.Persistence.ComponentTests
 {
     using System;
@@ -7,13 +8,13 @@ namespace NServiceBus.Persistence.ComponentTests
     using NUnit.Framework;
 
     [TestFixture]
-    public class When_worker_tries_to_complete_saga_update_by_another : SagaPersisterTests<TestSaga,TestSagaData>
+    public class When_worker_tries_to_complete_saga_update_by_another : SagaPersisterTests<TestSaga, TestSagaData>
     {
         [Test]
         public async Task Should_fail()
         {
             var correlationPropertyData = Guid.NewGuid().ToString();
-            var saga = new TestSagaData { SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
+            var saga = new TestSagaData {SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow};
 
             await SaveSaga(saga);
 

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/SubscriptionStorageTests.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/SubscriptionStorageTests.cs
@@ -11,9 +11,6 @@
     [TestFixture]
     class SubscriptionStorageTests
     {
-        PersistenceTestsConfiguration configuration;
-        ISubscriptionStorage storage;
-
         [OneTimeSetUp]
         public async Task OneTimeSetUp()
         {
@@ -67,7 +64,7 @@
             }, new ContextBag());
 
             Assert.AreEqual(2, subscribers.Count());
-            CollectionAssert.AreEquivalent(new[] { "address1", "address2" }, subscribers.Select(s => s.TransportAddress));
+            CollectionAssert.AreEquivalent(new[] {"address1", "address2"}, subscribers.Select(s => s.TransportAddress));
         }
 
         [Test]
@@ -102,7 +99,7 @@
             }, new ContextBag());
 
             Assert.AreEqual(2, subscribers.Count());
-            CollectionAssert.AreEquivalent(new[] { "address", "address" }, subscribers.Select(s => s.TransportAddress));
+            CollectionAssert.AreEquivalent(new[] {"address", "address"}, subscribers.Select(s => s.TransportAddress));
         }
 
         [Test]
@@ -211,5 +208,8 @@
         {
             return new MessageType(Guid.NewGuid().ToString("N"), "1.0.0");
         }
+
+        PersistenceTestsConfiguration configuration;
+        ISubscriptionStorage storage;
     }
 }

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/TimeoutStorageTests.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/TimeoutStorageTests.cs
@@ -9,8 +9,6 @@
     [TestFixture]
     public class TimeoutStorageTests
     {
-        PersistenceTestsConfiguration configuration;
-
         [OneTimeSetUp]
         public async Task OneTimeSetUp()
         {
@@ -180,5 +178,7 @@
 
             Assert.That(result.NextTimeToQuery, Is.EqualTo(now.AddMinutes(1)).Within(100).Milliseconds);
         }
+
+        PersistenceTestsConfiguration configuration;
     }
 }

--- a/src/NServiceBus.Storage.MongoDB.Tests/Migration/SagaMigrationPersisterTests.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/Migration/SagaMigrationPersisterTests.cs
@@ -1,13 +1,13 @@
-﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
-using MongoDB.Bson;
-using MongoDB.Bson.Serialization;
-using MongoDB.Driver;
-using NServiceBus.Persistence.ComponentTests;
-
-namespace NServiceBus.Storage.MongoDB.Tests
+﻿namespace NServiceBus.Storage.MongoDB.Tests
 {
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using global::MongoDB.Bson;
+    using global::MongoDB.Bson.Serialization;
+    using global::MongoDB.Driver;
+    using Persistence.ComponentTests;
+
     class SagaMigrationPersisterTests : SagaPersisterTests
     {
         protected Task PrepareSagaCollection<TSagaData>(TSagaData data, string correlationPropertyName) where TSagaData : IContainSagaData
@@ -25,7 +25,8 @@ namespace NServiceBus.Storage.MongoDB.Tests
 
             var propertyElementName = BsonClassMap.LookupClassMap(sagaDataType).AllMemberMaps.First(m => m.MemberName == correlationPropertyName).ElementName;
 
-            var indexModel = new CreateIndexModel<BsonDocument>(new BsonDocumentIndexKeysDefinition<BsonDocument>(new BsonDocument(propertyElementName, 1)), new CreateIndexOptions() { Unique = true });
+            var indexModel = new CreateIndexModel<BsonDocument>(new BsonDocumentIndexKeysDefinition<BsonDocument>(new BsonDocument(propertyElementName, 1)), new CreateIndexOptions
+                {Unique = true});
 
             await collection.Indexes.CreateOneAsync(indexModel);
 

--- a/src/NServiceBus.Storage.MongoDB.Tests/Migration/When_migrating_NServiceBus_dot_MongoDB.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/Migration/When_migrating_NServiceBus_dot_MongoDB.cs
@@ -1,15 +1,13 @@
-﻿using System;
-using System.Threading.Tasks;
-using MongoDB.Bson;
-using NServiceBus.Persistence.ComponentTests;
-using NUnit.Framework;
-
-namespace NServiceBus.Storage.MongoDB.Tests
+﻿namespace NServiceBus.Storage.MongoDB.Tests
 {
+    using System;
+    using System.Threading.Tasks;
+    using global::MongoDB.Bson;
+    using NUnit.Framework;
+    using Persistence.ComponentTests;
+
     class When_migrating_NServiceBus_dot_MongoDB : SagaMigrationPersisterTests
     {
-        readonly Func<Type, string> collectionNamingConvention = t => t.Name;
-
         [Test]
         public async Task Persister_works_with_existing_sagas()
         {
@@ -34,7 +32,7 @@ namespace NServiceBus.Storage.MongoDB.Tests
                 return d.ToBsonDocument();
             });
 
-            var retrievedSagaData = await GetById<NServiceBusMongoDBLegacySaga,NServiceBusMongoDBLegacySagaData>(legacySagaData.Id);
+            var retrievedSagaData = await GetById<NServiceBusMongoDBLegacySaga, NServiceBusMongoDBLegacySagaData>(legacySagaData.Id);
 
             Assert.IsNotNull(retrievedSagaData, "Saga was not retrieved");
             Assert.AreEqual(legacySagaData.OriginalMessageId, retrievedSagaData.OriginalMessageId, "OriginalMessageId does not match");
@@ -42,6 +40,8 @@ namespace NServiceBus.Storage.MongoDB.Tests
             Assert.AreEqual(legacySagaData.SomeCorrelationPropertyId, retrievedSagaData.SomeCorrelationPropertyId, "SomeCorrelationPropertyId does not match");
             Assert.AreEqual(legacySagaData.SomeUpdatableSagaData, retrievedSagaData.SomeUpdatableSagaData, "SomeUpdatableSagaData does not match");
         }
+
+        readonly Func<Type, string> collectionNamingConvention = t => t.Name;
 
         class NServiceBusMongoDBLegacySaga : Saga<NServiceBusMongoDBLegacySagaData>, IAmStartedByMessages<MigrationStartMessage>
         {
@@ -58,29 +58,24 @@ namespace NServiceBus.Storage.MongoDB.Tests
 
         class NServiceBusMongoDBLegacySagaData : IContainSagaData
         {
+            public Guid SomeCorrelationPropertyId { get; set; }
+
+            public int SomeUpdatableSagaData { get; set; }
             public Guid Id { get; set; }
 
             public string OriginalMessageId { get; set; }
 
             public string Originator { get; set; }
-
-            public Guid SomeCorrelationPropertyId { get; set; }
-
-            public int SomeUpdatableSagaData { get; set; }
         }
     }
 }
 
 namespace NServiceBus.MongoDB
 {
+    using System;
+
     class NServiceBusMongoDBLegacySagaData : IContainSagaData
     {
-        public Guid Id { get; set; }
-
-        public string OriginalMessageId { get; set; }
-
-        public string Originator { get; set; }
-
         public int DocumentVersion { get; set; } //From NServiceBus.MongoDB.IHaveDocumentVersion
 
         public int ETag { get; set; } //From NServiceBus.MongoDB.IHaveDocumentVersion
@@ -88,5 +83,10 @@ namespace NServiceBus.MongoDB
         public Guid SomeCorrelationPropertyId { get; set; }
 
         public int SomeUpdatableSagaData { get; set; }
+        public Guid Id { get; set; }
+
+        public string OriginalMessageId { get; set; }
+
+        public string Originator { get; set; }
     }
 }

--- a/src/NServiceBus.Storage.MongoDB.Tests/Migration/When_migrating_NServiceBus_dot_Persistence_dot_MongoDb.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/Migration/When_migrating_NServiceBus_dot_Persistence_dot_MongoDb.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Threading.Tasks;
-using NServiceBus.Persistence.ComponentTests;
-using NUnit.Framework;
-
-namespace NServiceBus.Storage.MongoDB.Tests
+﻿namespace NServiceBus.Storage.MongoDB.Tests
 {
+    using System;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+    using Persistence.ComponentTests;
+
     class When_migrating_NServiceBus_dot_Persistence_dot_MongoDb : SagaMigrationPersisterTests
     {
         [Test]
@@ -24,7 +24,7 @@ namespace NServiceBus.Storage.MongoDB.Tests
 
             await PrepareSagaCollection(legacySagaData, nameof(legacySagaData.SomeCorrelationPropertyId));
 
-            var retrievedSagaData = await GetById<NServiceBusPersistenceMongoDBLegacySaga,NServiceBusPersistenceMongoDBLegacySagaData>(legacySagaData.Id);
+            var retrievedSagaData = await GetById<NServiceBusPersistenceMongoDBLegacySaga, NServiceBusPersistenceMongoDBLegacySagaData>(legacySagaData.Id);
 
             Assert.IsNotNull(retrievedSagaData, "Saga was not retrieved");
             Assert.AreEqual(legacySagaData.OriginalMessageId, retrievedSagaData.OriginalMessageId, "OriginalMessageId does not match");
@@ -48,33 +48,33 @@ namespace NServiceBus.Storage.MongoDB.Tests
 
         class NServiceBusPersistenceMongoDBLegacySagaData : IContainSagaData
         {
+            public Guid SomeCorrelationPropertyId { get; set; }
+
+            public int SomeUpdatableSagaData { get; set; }
             public Guid Id { get; set; }
 
             public string OriginalMessageId { get; set; }
 
             public string Originator { get; set; }
-
-            public Guid SomeCorrelationPropertyId { get; set; }
-
-            public int SomeUpdatableSagaData { get; set; }
         }
     }
 }
 
 namespace NServiceBus.Persistence.MongoDB
 {
+    using System;
+
     class NServiceBusPersistenceMongoDBLegacySagaData : IContainSagaData
     {
-        public Guid Id { get; set; }
-
-        public string OriginalMessageId { get; set; }
-
-        public string Originator { get; set; }
-
         public int Version { get; set; }
 
         public Guid SomeCorrelationPropertyId { get; set; }
 
         public int SomeUpdatableSagaData { get; set; }
+        public Guid Id { get; set; }
+
+        public string OriginalMessageId { get; set; }
+
+        public string Originator { get; set; }
     }
 }

--- a/src/NServiceBus.Storage.MongoDB.Tests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/PersistenceTestsConfiguration.cs
@@ -1,17 +1,17 @@
-﻿using System;
-using System.Globalization;
-using System.Threading.Tasks;
-using MongoDB.Driver;
-using NServiceBus.Gateway.Deduplication;
-using NServiceBus.Outbox;
-using NServiceBus.Sagas;
-using NServiceBus.Storage.MongoDB;
-using NServiceBus.Storage.MongoDB.Tests;
-using NServiceBus.Timeout.Core;
-using NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions;
-
-namespace NServiceBus.Persistence.ComponentTests
+﻿namespace NServiceBus.Persistence.ComponentTests
 {
+    using System;
+    using System.Globalization;
+    using System.Threading.Tasks;
+    using Gateway.Deduplication;
+    using global::MongoDB.Driver;
+    using Outbox;
+    using Sagas;
+    using Storage.MongoDB;
+    using Storage.MongoDB.Tests;
+    using Timeout.Core;
+    using Unicast.Subscriptions.MessageDrivenSubscriptions;
+
     public partial class PersistenceTestsConfiguration
     {
         public PersistenceTestsConfiguration(string versionElementName, Func<Type, string> collectionNamingConvention)

--- a/src/NServiceBus.Storage.MongoDB.Tests/Sagas/EqualityExtensions.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/Sagas/EqualityExtensions.cs
@@ -1,7 +1,7 @@
-﻿using System;
-
-namespace NServiceBus.Storage.MongoDB.Tests
+﻿namespace NServiceBus.Storage.MongoDB.Tests
 {
+    using System;
+
     public static class EqualityExtensions
     {
         public static bool EqualTo<T>(this T item, object obj, Func<T, T, bool> equals) where T : class

--- a/src/NServiceBus.Storage.MongoDB.Tests/Sagas/PropertyTypesTestSaga.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/Sagas/PropertyTypesTestSaga.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-
-namespace NServiceBus.Storage.MongoDB.Tests
+﻿namespace NServiceBus.Storage.MongoDB.Tests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
     public class PropertyTypesTestSaga : Saga<PropertyTypesTestSagaData>, IAmStartedByMessages<PropertyTypesTestSagaDataStartMessage>
     {
         public Task Handle(PropertyTypesTestSagaDataStartMessage message, IMessageHandlerContext context)
@@ -19,12 +19,6 @@ namespace NServiceBus.Storage.MongoDB.Tests
 
     public class PropertyTypesTestSagaData : IContainSagaData
     {
-        public virtual Guid Id { get; set; }
-
-        public virtual string Originator { get; set; }
-
-        public virtual string OriginalMessageId { get; set; }
-
         public virtual RelatedClass RelatedClass { get; set; }
 
         public virtual IList<OrderLine> OrderLines { get; set; }
@@ -36,6 +30,11 @@ namespace NServiceBus.Storage.MongoDB.Tests
         public virtual TestComponent TestComponent { get; set; }
 
         public virtual PolymorphicPropertyBase PolymorphicRelatedProperty { get; set; }
+        public virtual Guid Id { get; set; }
+
+        public virtual string Originator { get; set; }
+
+        public virtual string OriginalMessageId { get; set; }
 
         public override bool Equals(object obj)
         {
@@ -70,7 +69,8 @@ namespace NServiceBus.Storage.MongoDB.Tests
 
     public enum StatusEnum
     {
-        SomeStatus, AnotherStatus
+        SomeStatus,
+        AnotherStatus
     }
 
     public class TestComponent

--- a/src/NServiceBus.Storage.MongoDB.Tests/Sagas/When_persisting_a_saga_entity.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/Sagas/When_persisting_a_saga_entity.cs
@@ -1,16 +1,12 @@
-﻿using System;
-using System.Threading.Tasks;
-using NServiceBus.Persistence.ComponentTests;
-using NUnit.Framework;
-
-namespace NServiceBus.Storage.MongoDB.Tests
+﻿namespace NServiceBus.Storage.MongoDB.Tests
 {
+    using System;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+    using Persistence.ComponentTests;
+
     public class When_persisting_a_saga_entity : SagaPersisterTests<PropertyTypesTestSaga, PropertyTypesTestSagaData>
     {
-        PropertyTypesTestSagaData entity;
-        PropertyTypesTestSagaData savedEntity;
-        RelatedClass relatedClass;
-
         [SetUp]
         public async Task Setup()
         {
@@ -20,8 +16,8 @@ namespace NServiceBus.Storage.MongoDB.Tests
                 TestComponent = new TestComponent {Property = "Prop"},
                 DateTimeProperty = DateTime.Parse("12/02/2010 12:00:00.01").ToUniversalTime(),
                 Status = StatusEnum.AnotherStatus,
-                PolymorphicRelatedProperty = new PolymorphicProperty { SomeInt = 9 },
-                RelatedClass = new RelatedClass { Id = Guid.NewGuid() }
+                PolymorphicRelatedProperty = new PolymorphicProperty {SomeInt = 9},
+                RelatedClass = new RelatedClass {Id = Guid.NewGuid()}
             };
 
             relatedClass = entity.RelatedClass;
@@ -60,5 +56,9 @@ namespace NServiceBus.Storage.MongoDB.Tests
         {
             Assert.AreEqual(relatedClass.Id, savedEntity.RelatedClass.Id);
         }
+
+        PropertyTypesTestSagaData entity;
+        PropertyTypesTestSagaData savedEntity;
+        RelatedClass relatedClass;
     }
 }

--- a/src/NServiceBus.Storage.MongoDB/Configuration/CompatibilitySettings.cs
+++ b/src/NServiceBus.Storage.MongoDB/Configuration/CompatibilitySettings.cs
@@ -6,6 +6,7 @@
     using Storage.MongoDB;
 
     /// <summary>
+    /// Provides settings to configure compatibility with community MongoDB persistence packages.
     /// </summary>
     public class CompatibilitySettings : ExposeSettings
     {

--- a/src/NServiceBus.Storage.MongoDB/Configuration/CompatibilitySettings.cs
+++ b/src/NServiceBus.Storage.MongoDB/Configuration/CompatibilitySettings.cs
@@ -1,16 +1,17 @@
-﻿using System;
-using NServiceBus.Configuration.AdvancedExtensibility;
-using NServiceBus.Settings;
-using NServiceBus.Storage.MongoDB;
-
-namespace NServiceBus
+﻿namespace NServiceBus
 {
+    using System;
+    using Configuration.AdvancedExtensibility;
+    using Settings;
+    using Storage.MongoDB;
+
     /// <summary>
-    ///
     /// </summary>
     public class CompatibilitySettings : ExposeSettings
     {
-        internal CompatibilitySettings(SettingsHolder settingsHolder) : base(settingsHolder) { }
+        internal CompatibilitySettings(SettingsHolder settingsHolder) : base(settingsHolder)
+        {
+        }
 
         /// <summary>
         /// The version element name with MongoDB conventions applied

--- a/src/NServiceBus.Storage.MongoDB/Configuration/MongoSettingsExtensions.cs
+++ b/src/NServiceBus.Storage.MongoDB/Configuration/MongoSettingsExtensions.cs
@@ -6,6 +6,7 @@
     using Storage.MongoDB;
 
     /// <summary>
+    /// Extension methods to configure the MongoDB persistence.
     /// </summary>
     public static class MongoSettingsExtensions
     {

--- a/src/NServiceBus.Storage.MongoDB/Configuration/MongoSettingsExtensions.cs
+++ b/src/NServiceBus.Storage.MongoDB/Configuration/MongoSettingsExtensions.cs
@@ -1,12 +1,11 @@
-﻿using System;
-using MongoDB.Driver;
-using NServiceBus.Configuration.AdvancedExtensibility;
-using NServiceBus.Storage.MongoDB;
-
-namespace NServiceBus
+﻿namespace NServiceBus
 {
+    using System;
+    using Configuration.AdvancedExtensibility;
+    using MongoDB.Driver;
+    using Storage.MongoDB;
+
     /// <summary>
-    ///
     /// </summary>
     public static class MongoSettingsExtensions
     {

--- a/src/NServiceBus.Storage.MongoDB/MongoPersistence.cs
+++ b/src/NServiceBus.Storage.MongoDB/MongoPersistence.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using MongoDB.Driver;
-using NServiceBus.Features;
-using NServiceBus.Persistence;
-using NServiceBus.Storage.MongoDB;
-
-namespace NServiceBus
+﻿namespace NServiceBus
 {
+    using System;
+    using Features;
+    using MongoDB.Driver;
+    using Persistence;
+    using Storage.MongoDB;
+
     /// <summary>
     /// </summary>
     public class MongoPersistence : PersistenceDefinition
@@ -40,13 +40,13 @@ namespace NServiceBus
             Supports<StorageType.Subscriptions>(s => s.EnableFeatureByDefault<SubscriptionStorage>());
         }
 
-        static IMongoClient defaultClient;
-
         internal static MongoDatabaseSettings DefaultDatabaseSettings { get; } = new MongoDatabaseSettings
         {
             ReadConcern = ReadConcern.Majority,
             WriteConcern = WriteConcern.WMajority,
             ReadPreference = ReadPreference.Primary
         };
+
+        static IMongoClient defaultClient;
     }
 }

--- a/src/NServiceBus.Storage.MongoDB/Outbox/MongoOutboxTransaction.cs
+++ b/src/NServiceBus.Storage.MongoDB/Outbox/MongoOutboxTransaction.cs
@@ -1,19 +1,19 @@
-﻿using System;
-using System.Threading.Tasks;
-using MongoDB.Driver;
-using NServiceBus.Extensibility;
-using NServiceBus.Outbox;
-
-namespace NServiceBus.Storage.MongoDB
+﻿namespace NServiceBus.Storage.MongoDB
 {
+    using System;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using global::MongoDB.Driver;
+    using Outbox;
+
     class MongoOutboxTransaction : OutboxTransaction
     {
-        public StorageSession StorageSession { get; }
-
         public MongoOutboxTransaction(IClientSessionHandle mongoSession, string databaseName, ContextBag context, Func<Type, string> collectionNamingConvention)
         {
             StorageSession = new StorageSession(mongoSession, databaseName, context, collectionNamingConvention, false);
         }
+
+        public StorageSession StorageSession { get; }
 
         public Task Commit()
         {

--- a/src/NServiceBus.Storage.MongoDB/Outbox/MongoOutboxTransactionFactory.cs
+++ b/src/NServiceBus.Storage.MongoDB/Outbox/MongoOutboxTransactionFactory.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Threading.Tasks;
-using MongoDB.Driver;
-using NServiceBus.Extensibility;
-using NServiceBus.Outbox;
-
-namespace NServiceBus.Storage.MongoDB
+﻿namespace NServiceBus.Storage.MongoDB
 {
+    using System;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using global::MongoDB.Driver;
+    using Outbox;
+
     class MongoOutboxTransactionFactory
     {
         public MongoOutboxTransactionFactory(IMongoClient client, string databaseName, Func<Type, string> collectionNamingConvention)

--- a/src/NServiceBus.Storage.MongoDB/Outbox/OutboxPersister.cs
+++ b/src/NServiceBus.Storage.MongoDB/Outbox/OutboxPersister.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Threading.Tasks;
-using MongoDB.Driver;
-using NServiceBus.Extensibility;
-using NServiceBus.Outbox;
-
-namespace NServiceBus.Storage.MongoDB
+﻿namespace NServiceBus.Storage.MongoDB
 {
+    using System;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using global::MongoDB.Driver;
+    using Outbox;
+
     class OutboxPersister : IOutboxStorage
     {
         public OutboxPersister(IMongoClient client, string databaseName, Func<Type, string> collectionNamingConvention)
@@ -36,7 +36,7 @@ namespace NServiceBus.Storage.MongoDB
             var mongoOutboxTransaction = (MongoOutboxTransaction)transaction;
             var storageSession = mongoOutboxTransaction.StorageSession;
 
-            return storageSession.InsertOneAsync(new OutboxRecord { Id = message.MessageId, TransportOperations = message.TransportOperations });
+            return storageSession.InsertOneAsync(new OutboxRecord {Id = message.MessageId, TransportOperations = message.TransportOperations});
         }
 
         public async Task SetAsDispatched(string messageId, ContextBag context)

--- a/src/NServiceBus.Storage.MongoDB/Outbox/OutboxRecord.cs
+++ b/src/NServiceBus.Storage.MongoDB/Outbox/OutboxRecord.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using NServiceBus.Outbox;
-
-namespace NServiceBus.Storage.MongoDB
+﻿namespace NServiceBus.Storage.MongoDB
 {
+    using System;
+    using Outbox;
+
     class OutboxRecord
     {
         public string Id { get; set; }

--- a/src/NServiceBus.Storage.MongoDB/Outbox/OutboxStorage.cs
+++ b/src/NServiceBus.Storage.MongoDB/Outbox/OutboxStorage.cs
@@ -1,20 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using MongoDB.Bson.Serialization;
-using MongoDB.Bson.Serialization.Options;
-using MongoDB.Bson.Serialization.Serializers;
-using MongoDB.Driver;
-using NServiceBus.Features;
-using NServiceBus.Outbox;
-
-namespace NServiceBus.Storage.MongoDB
+﻿namespace NServiceBus.Storage.MongoDB
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Features;
+    using global::MongoDB.Bson.Serialization;
+    using global::MongoDB.Bson.Serialization.Options;
+    using global::MongoDB.Bson.Serialization.Serializers;
+    using global::MongoDB.Driver;
+    using Outbox;
+
     class OutboxStorage : Feature
     {
         OutboxStorage()
         {
-            DependsOn<Features.Outbox>();
+            DependsOn<Outbox>();
             DependsOn<SynchronizedStorage>();
         }
 

--- a/src/NServiceBus.Storage.MongoDB/Sagas/SagaPersister.cs
+++ b/src/NServiceBus.Storage.MongoDB/Sagas/SagaPersister.cs
@@ -1,14 +1,14 @@
-﻿using System;
-using System.Threading.Tasks;
-using MongoDB.Bson;
-using MongoDB.Bson.Serialization;
-using MongoDB.Driver;
-using NServiceBus.Extensibility;
-using NServiceBus.Persistence;
-using NServiceBus.Sagas;
-
-namespace NServiceBus.Storage.MongoDB
+﻿namespace NServiceBus.Storage.MongoDB
 {
+    using System;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using global::MongoDB.Bson;
+    using global::MongoDB.Bson.Serialization;
+    using global::MongoDB.Driver;
+    using Persistence;
+    using Sagas;
+
     class SagaPersister : ISagaPersister
     {
         public SagaPersister(string versionElementName)
@@ -81,8 +81,9 @@ namespace NServiceBus.Storage.MongoDB
             return default;
         }
 
-        const string idElementName = "_id";
         readonly string versionElementName;
         readonly FilterDefinitionBuilder<BsonDocument> filterBuilder = Builders<BsonDocument>.Filter;
+
+        const string idElementName = "_id";
     }
 }

--- a/src/NServiceBus.Storage.MongoDB/Sagas/SagaStorage.cs
+++ b/src/NServiceBus.Storage.MongoDB/Sagas/SagaStorage.cs
@@ -1,17 +1,17 @@
-using System;
-using MongoDB.Bson;
-using MongoDB.Bson.Serialization;
-using MongoDB.Driver;
-using NServiceBus.Features;
-using NServiceBus.Sagas;
-
 namespace NServiceBus.Storage.MongoDB
 {
+    using System;
+    using Features;
+    using global::MongoDB.Bson;
+    using global::MongoDB.Bson.Serialization;
+    using global::MongoDB.Driver;
+    using Sagas;
+
     class SagaStorage : Feature
     {
         SagaStorage()
         {
-            DependsOn<Features.Sagas>();
+            DependsOn<Sagas>();
             DependsOn<SynchronizedStorage>();
         }
 
@@ -60,7 +60,8 @@ namespace NServiceBus.Storage.MongoDB
                 {
                     var propertyElementName = sagaMetadata.SagaEntityType.GetElementName(property.Name);
 
-                    var indexModel = new CreateIndexModel<BsonDocument>(new BsonDocumentIndexKeysDefinition<BsonDocument>(new BsonDocument(propertyElementName, 1)), new CreateIndexOptions() { Unique = true });
+                    var indexModel = new CreateIndexModel<BsonDocument>(new BsonDocumentIndexKeysDefinition<BsonDocument>(new BsonDocument(propertyElementName, 1)), new CreateIndexOptions
+                        {Unique = true});
                     database.GetCollection<BsonDocument>(collectionName).Indexes.CreateOne(indexModel);
                 }
                 else

--- a/src/NServiceBus.Storage.MongoDB/Sagas/TypeExtensions.cs
+++ b/src/NServiceBus.Storage.MongoDB/Sagas/TypeExtensions.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using MongoDB.Bson.Serialization;
-
-namespace NServiceBus.Storage.MongoDB
+﻿namespace NServiceBus.Storage.MongoDB
 {
+    using System;
+    using global::MongoDB.Bson.Serialization;
+
     static class TypeExtensions
     {
         public static string GetElementName(this Type type, string propertyName)

--- a/src/NServiceBus.Storage.MongoDB/Subscriptions/SubscriptionPersister.cs
+++ b/src/NServiceBus.Storage.MongoDB/Subscriptions/SubscriptionPersister.cs
@@ -1,13 +1,13 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
-using MongoDB.Driver;
-using NServiceBus.Extensibility;
-using NServiceBus.Logging;
-using NServiceBus.Unicast.Subscriptions;
-using NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions;
-
-namespace NServiceBus.Storage.MongoDB
+﻿namespace NServiceBus.Storage.MongoDB
 {
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using global::MongoDB.Driver;
+    using Logging;
+    using Unicast.Subscriptions;
+    using Unicast.Subscriptions.MessageDrivenSubscriptions;
+
     class SubscriptionPersister : ISubscriptionStorage
     {
         public SubscriptionPersister(IMongoCollection<EventSubscription> subscriptionsCollection)
@@ -50,6 +50,7 @@ namespace NServiceBus.Storage.MongoDB
             {
                 messageTypeNames.Add(messageType.TypeName);
             }
+
             var filter = filterBuilder.In(s => s.MessageTypeName, messageTypeNames);
             // This projection allows a covered query:
             var projection = Builders<EventSubscription>.Projection
@@ -137,12 +138,12 @@ namespace NServiceBus.Storage.MongoDB
                     .Ascending(x => x.MessageTypeName)
                     .Ascending(x => x.TransportAddress),
                 new CreateIndexOptions
-                { Unique = true });
+                    {Unique = true});
             var searchIndex = new CreateIndexModel<EventSubscription>(Builders<EventSubscription>.IndexKeys
                 .Ascending(x => x.MessageTypeName)
                 .Ascending(x => x.TransportAddress)
                 .Ascending(x => x.Endpoint));
-            subscriptionsCollection.Indexes.CreateMany(new[] { uniqueIndex, searchIndex });
+            subscriptionsCollection.Indexes.CreateMany(new[] {uniqueIndex, searchIndex});
         }
 
         IMongoCollection<EventSubscription> subscriptionsCollection;

--- a/src/NServiceBus.Storage.MongoDB/Subscriptions/SubscriptionStorage.cs
+++ b/src/NServiceBus.Storage.MongoDB/Subscriptions/SubscriptionStorage.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using MongoDB.Driver;
-using NServiceBus.Features;
-using NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions;
-
-namespace NServiceBus.Storage.MongoDB
+﻿namespace NServiceBus.Storage.MongoDB
 {
+    using System;
+    using Features;
+    using global::MongoDB.Driver;
+    using Unicast.Subscriptions.MessageDrivenSubscriptions;
+
     class SubscriptionStorage : Feature
     {
         public SubscriptionStorage()

--- a/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/StorageSessionAdapter.cs
+++ b/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/StorageSessionAdapter.cs
@@ -1,15 +1,13 @@
-﻿using System.Threading.Tasks;
-using NServiceBus.Extensibility;
-using NServiceBus.Outbox;
-using NServiceBus.Persistence;
-using NServiceBus.Transport;
-
-namespace NServiceBus.Storage.MongoDB
+﻿namespace NServiceBus.Storage.MongoDB
 {
+    using System.Threading.Tasks;
+    using Extensibility;
+    using Outbox;
+    using Persistence;
+    using Transport;
+
     class StorageSessionAdapter : ISynchronizedStorageAdapter
     {
-        static readonly Task<CompletableSynchronizedStorageSession> emptyResult = Task.FromResult((CompletableSynchronizedStorageSession)null);
-
         public Task<CompletableSynchronizedStorageSession> TryAdapt(OutboxTransaction transaction, ContextBag context)
         {
             if (transaction is MongoOutboxTransaction mongoOutboxTransaction)
@@ -21,5 +19,6 @@ namespace NServiceBus.Storage.MongoDB
         }
 
         public Task<CompletableSynchronizedStorageSession> TryAdapt(TransportTransaction transportTransaction, ContextBag context) => emptyResult;
+        static readonly Task<CompletableSynchronizedStorageSession> emptyResult = Task.FromResult((CompletableSynchronizedStorageSession)null);
     }
 }

--- a/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/StorageSessionFactory.cs
+++ b/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/StorageSessionFactory.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Threading.Tasks;
-using MongoDB.Driver;
-using NServiceBus.Extensibility;
-using NServiceBus.Persistence;
-
-namespace NServiceBus.Storage.MongoDB
+﻿namespace NServiceBus.Storage.MongoDB
 {
+    using System;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using global::MongoDB.Driver;
+    using Persistence;
+
     class StorageSessionFactory : ISynchronizedStorage
     {
         public StorageSessionFactory(IMongoClient client, bool useTransactions, string databaseName, Func<Type, string> collectionNamingConvention)

--- a/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/SynchronizedStorage.cs
+++ b/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/SynchronizedStorage.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using MongoDB.Driver;
-using MongoDB.Driver.Core.Clusters;
-using NServiceBus.Features;
-
-namespace NServiceBus.Storage.MongoDB
+﻿namespace NServiceBus.Storage.MongoDB
 {
+    using System;
+    using Features;
+    using global::MongoDB.Driver;
+    using global::MongoDB.Driver.Core.Clusters;
+
     class SynchronizedStorage : Feature
     {
         protected override void Setup(FeatureConfigurationContext context)

--- a/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/SynchronizedStorageSessionExtensions.cs
+++ b/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/SynchronizedStorageSessionExtensions.cs
@@ -1,17 +1,15 @@
-﻿using System;
-using MongoDB.Driver;
-using NServiceBus.Persistence;
-using NServiceBus.Storage.MongoDB;
-
-namespace NServiceBus
+﻿namespace NServiceBus
 {
+    using System;
+    using MongoDB.Driver;
+    using Persistence;
+    using Storage.MongoDB;
+
     /// <summary>
-    ///
     /// </summary>
     public static class SynchronizedStorageSessionExtensions
     {
         /// <summary>
-        ///
         /// </summary>
         /// <param name="session"></param>
         /// <returns></returns>

--- a/src/NServiceBus.Storage.MongoDB/Utils/Guard.cs
+++ b/src/NServiceBus.Storage.MongoDB/Utils/Guard.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Collections;
-using System.Linq;
-using System.Reflection;
-
-namespace NServiceBus.Storage.MongoDB
+﻿namespace NServiceBus.Storage.MongoDB
 {
+    using System;
+    using System.Collections;
+    using System.Linq;
+    using System.Reflection;
+
     static class Guard
     {
         // ReSharper disable UnusedParameter.Global
@@ -40,6 +40,7 @@ namespace NServiceBus.Storage.MongoDB
             {
                 throw new ArgumentNullException(argumentName);
             }
+
             if (value.Count == 0)
             {
                 throw new ArgumentOutOfRangeException(argumentName);

--- a/src/NServiceBus.Storage.MongoDB/Utils/TaskEx.cs
+++ b/src/NServiceBus.Storage.MongoDB/Utils/TaskEx.cs
@@ -1,7 +1,7 @@
-using System.Threading.Tasks;
-
 namespace NServiceBus.Storage.MongoDB
 {
+    using System.Threading.Tasks;
+
     static class TaskEx
     {
         //TODO: remove when we update to 4.6 and can use Task.CompletedTask


### PR DESCRIPTION
I ran a code cleanup using the particular coding standards on this repo. Because the namespace imports on this repo have been placed outside before, this causes a lot of changes.