### PR TITLE
Support transaction on sharded clusters

### DIFF
--- a/src/NServiceBus.Storage.MongoDB.AcceptanceTests/NServiceBus.Storage.MongoDB.AcceptanceTests.csproj
+++ b/src/NServiceBus.Storage.MongoDB.AcceptanceTests/NServiceBus.Storage.MongoDB.AcceptanceTests.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.8.1" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />

--- a/src/NServiceBus.Storage.MongoDB.Tests/NServiceBus.Storage.MongoDB.Tests.csproj
+++ b/src/NServiceBus.Storage.MongoDB.Tests/NServiceBus.Storage.MongoDB.Tests.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.8.1" />
     <PackageReference Include="NServiceBus" Version="7.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />

--- a/src/NServiceBus.Storage.MongoDB/NServiceBus.Storage.MongoDB.csproj
+++ b/src/NServiceBus.Storage.MongoDB/NServiceBus.Storage.MongoDB.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.8.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.9.2" />
     <PackageReference Include="NServiceBus" Version="[7.1.10, 8.0.0)" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.1" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.2.1" PrivateAssets="All" />

--- a/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/SynchronizedStorage.cs
+++ b/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/SynchronizedStorage.cs
@@ -33,9 +33,11 @@
                 {
                     if (useTransactions)
                     {
-                        if (client.Cluster.Description.Type != ClusterType.ReplicaSet)
+                        var clusterType = client.Cluster.Description.Type;
+
+                        if (clusterType != ClusterType.ReplicaSet && clusterType != ClusterType.Sharded)
                         {
-                            throw new Exception("Transactions are only supported on a replica set. Disable support for transactions by calling 'EndpointConfiguration.UsePersistence<{nameof(MongoPersistence)}>().UseTransactions(false)'.");
+                            throw new Exception($"Transactions are supported only on replica set or sharded clusters. Disable support for transactions by calling 'EndpointConfiguration.UsePersistence<{nameof(MongoPersistence)}>().UseTransactions(false)'.");
                         }
 
                         try

--- a/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/SynchronizedStorage.cs
+++ b/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/SynchronizedStorage.cs
@@ -37,10 +37,10 @@
 
                         //HINT: cluster configuration check is needed as the built-in checks, executed during "StartTransaction() call,
                         //      do not detect if the cluster configuration is a supported one. Only the version ranges are validated.
-                        //      Without this check the exception would still be thrown but only later during message processing. 
+                        //      Without this check, exceptions will be thrown during message processing. 
                         if (clusterType != ClusterType.ReplicaSet && clusterType != ClusterType.Sharded)
                         {
-                            throw new Exception($"Transactions are supported only on replica set or sharded clusters. Disable support for transactions by calling 'EndpointConfiguration.UsePersistence<{nameof(MongoPersistence)}>().UseTransactions(false)'.");
+                            throw new Exception($"Transactions are only supported on replica sets or sharded clusters. Disable support for transactions by calling 'EndpointConfiguration.UsePersistence<{nameof(MongoPersistence)}>().UseTransactions(false)'.");
                         }
 
                         try

--- a/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/SynchronizedStorage.cs
+++ b/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/SynchronizedStorage.cs
@@ -35,6 +35,9 @@
                     {
                         var clusterType = client.Cluster.Description.Type;
 
+                        //HINT: cluster configuration check is needed as the built-in checks, executed during "StartTransaction() call,
+                        //      do not detect if the cluster configuration is a supported one. Only the version ranges are validated.
+                        //      Without this check the exception would still be thrown but only later during message processing. 
                         if (clusterType != ClusterType.ReplicaSet && clusterType != ClusterType.Sharded)
                         {
                             throw new Exception($"Transactions are supported only on replica set or sharded clusters. Disable support for transactions by calling 'EndpointConfiguration.UsePersistence<{nameof(MongoPersistence)}>().UseTransactions(false)'.");


### PR DESCRIPTION
## Description
MogoDb [supports](https://docs.mongodb.com/manual/core/transactions/#transactions-and-atomicity) multi-document transactions a.k.a. transactions in replica-set deployments on versions 4.0+ and shared-cluster on versions 4.2+.

### Support Check
The persister was too restrictive and failed when running on any other configuration than replica-set ver. 4.0+. This change makes sure that the persister enables shared-cluster deployments as well.

It is not possible to remove the check altogether and rely on the client library at this moment. The client library does the version and shared-cluster [check](https://github.com/mongodb/mongo-csharp-driver/blob/4696ab8e8033879a6cf26f0022f4d20b9e0870b9/src/MongoDB.Driver.Core/Core/Bindings/CoreSession.cs#L459) that align with documentation. However, for all other configurations, it checks **only the version number**.  The check logic has been introduced in the driver in [2.8.1 release](https://jira.mongodb.org/browse/CSHARP-2561?jql=project%20%3D%20CSHARP%20AND%20fixVersion%20%3D%202.8.1%20ORDER%20BY%20key%20ASC).

### Client SDK
To support transactions on sharded clusters and update to 2.9.0 version on MongoDB client SDK was also needed.