### PR TITLE
version update

### DIFF
--- a/src/NServiceBus.Storage.MongoDB.AcceptanceTests/NServiceBus.Storage.MongoDB.AcceptanceTests.csproj
+++ b/src/NServiceBus.Storage.MongoDB.AcceptanceTests/NServiceBus.Storage.MongoDB.AcceptanceTests.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.8.1" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />

--- a/src/NServiceBus.Storage.MongoDB.Tests/NServiceBus.Storage.MongoDB.Tests.csproj
+++ b/src/NServiceBus.Storage.MongoDB.Tests/NServiceBus.Storage.MongoDB.Tests.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.8.1" />
     <PackageReference Include="NServiceBus" Version="7.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />

--- a/src/NServiceBus.Storage.MongoDB/NServiceBus.Storage.MongoDB.csproj
+++ b/src/NServiceBus.Storage.MongoDB/NServiceBus.Storage.MongoDB.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.8.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.9.2" />
     <PackageReference Include="NServiceBus" Version="[7.1.10, 8.0.0)" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.1" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.2.1" PrivateAssets="All" />


### PR DESCRIPTION
PR on top of #32 

we need to target 2.9 as 2.8 doesn't support sharded clusters from a client perspective.
I haven't added an upper dependency range as this hasn't been something decided by the squad yet, I think we can do this as a dedicated PR.