### PR TITLE
Implement pessimistic saga locking

### DIFF
--- a/src/NServiceBus.Storage.MongoDB.AcceptanceTests/When_storing_saga_with_high_contention.cs
+++ b/src/NServiceBus.Storage.MongoDB.AcceptanceTests/When_storing_saga_with_high_contention.cs
@@ -1,0 +1,172 @@
+﻿namespace NServiceBus.Persistence.AcceptanceTests.SagaDataStorage
+{
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_storing_saga_with_high_contention : NServiceBusAcceptanceTest
+    {
+        [Test]
+        [Repeat(20)]
+        public async Task Should_use_saga_data_type_name()
+        {
+            
+            File.AppendAllText(@"C:\data\saga.contention.stats.txt", string.Empty);
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<SagaEndpoint>(b => b
+                    .When(session => session.SendLocal(new StartSaga { SomeId = Guid.NewGuid() })))
+                .Done(c => c.Done)
+                .Run();
+
+            Console.WriteLine(context.Elapsed);
+            Console.WriteLine(context.NumberOfRetries);
+
+            File.AppendAllText(@"C:\data\saga.contention.stats.txt", $"{context.Elapsed}; {context.NumberOfMessages}; {context.NumberOfRetries}{Environment.NewLine}");
+        }
+
+        public class Context : ScenarioContext
+        {
+            long numberOfRetries;
+            public bool Done { get; set; }
+            public bool SagaStarted { get; set; }
+            public bool MessagesSent { get; set; }
+            public int HitCount { get; set; }
+
+            public Stopwatch Watch { get; } = new Stopwatch();
+
+            public TimeSpan Elapsed => Watch.Elapsed;
+
+            public int NumberOfMessages { get; } = 200;
+
+            public long NumberOfRetries => Interlocked.Read(ref numberOfRetries);
+
+            public void IncrementNumberOfRetries()
+            {
+                Interlocked.Increment(ref numberOfRetries);
+            }
+        }
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer, Context>((b, c) =>
+                {
+                    b.LimitMessageProcessingConcurrencyTo(c.NumberOfMessages);
+                    var recoverability = b.Recoverability();
+                    recoverability.Immediate(s =>
+                    {
+                        s.OnMessageBeingRetried(m =>
+                        {
+                            c.IncrementNumberOfRetries();
+                            return Task.FromResult(0);
+                        });
+                        s.NumberOfRetries(c.NumberOfMessages);
+                    });
+                    recoverability.Delayed(s => s.NumberOfRetries(0));
+                });
+            }
+
+            public class HighContentionSaga : Saga<HighContentionSaga.HighContentionSagaData>, IAmStartedByMessages<StartSaga>, IHandleMessages<AdditionalMessage>
+            {
+                public Context TestContext { get; set; }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<HighContentionSagaData> mapper)
+                {
+                    mapper.ConfigureMapping<StartSaga>(m => m.SomeId).ToSaga(d => d.SomeId);
+                    mapper.ConfigureMapping<AdditionalMessage>(m => m.SomeId).ToSaga(d => d.SomeId);
+                }
+
+                public Task Handle(StartSaga message, IMessageHandlerContext context)
+                {
+                    Data.SomeId = message.SomeId;
+                    TestContext.Watch.Start();
+                    TestContext.SagaStarted = true;
+
+                    return context.SendLocal(new FireInTheWhole { SomeId = message.SomeId });
+                }
+
+                public class HighContentionSagaData : ContainSagaData
+                {
+                    public int Hit { get; set; }
+                    public Guid SomeId { get; set; }
+                }
+
+                public async Task Handle(AdditionalMessage message, IMessageHandlerContext context)
+                {
+                    Data.Hit++;
+
+                    if (Data.Hit >= TestContext.NumberOfMessages)
+                    {
+                        MarkAsComplete();
+                        await context.SendLocal(new DoneSaga { SomeId = message.SomeId, HitCount = Data.Hit });
+                    }
+                }
+            }
+
+            class CreateLoadHandler : IHandleMessages<FireInTheWhole>
+            {
+                readonly Context testContext;
+
+                public CreateLoadHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public async Task Handle(FireInTheWhole message, IMessageHandlerContext context)
+                {
+                    await Task.WhenAll(Enumerable.Range(0, testContext.NumberOfMessages).Select(i => context.SendLocal(new AdditionalMessage { SomeId = message.SomeId })));
+                    testContext.MessagesSent = true;
+                }
+            }
+
+            class DoneHandler : IHandleMessages<DoneSaga>
+            {
+                readonly Context testContext;
+
+                public DoneHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(DoneSaga message, IMessageHandlerContext context)
+                {
+                    testContext.Watch.Stop();
+                    testContext.HitCount = message.HitCount;
+                    testContext.Done = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class StartSaga : IMessage
+        {
+            public Guid SomeId { get; set; }
+        }
+
+        public class DoneSaga : IMessage
+        {
+            public Guid SomeId { get; set; }
+            public int HitCount { get; set; }
+        }
+
+        public class FireInTheWhole : IMessage
+        {
+            public Guid SomeId { get; set; }
+        }
+
+        public class AdditionalMessage : IMessage
+        {
+            public Guid SomeId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Storage.MongoDB.AcceptanceTests/When_storing_saga_with_high_contention.cs
+++ b/src/NServiceBus.Storage.MongoDB.AcceptanceTests/When_storing_saga_with_high_contention.cs
@@ -14,6 +14,7 @@
     [TestFixture]
     public class When_storing_saga_with_high_contention : NServiceBusAcceptanceTest
     {
+        [Ignore("only for manual execution")]
         [Test]
         [Repeat(20)]
         public async Task Should_use_saga_data_type_name()

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/IPersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/IPersistenceTestsConfiguration.cs
@@ -22,6 +22,8 @@ namespace NServiceBus.Persistence.ComponentTests
 
         bool SupportsTimeouts { get; }
 
+        bool SupportsPessimisticConcurrency { get; }
+
         ISagaIdGenerator SagaIdGenerator { get; }
 
         ISagaPersister SagaStorage { get; }

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/RequiresExtensionsForPersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/RequiresExtensionsForPersistenceTestsConfiguration.cs
@@ -43,5 +43,21 @@ namespace NServiceBus.Persistence.ComponentTests
                 Assert.Ignore("Ignoring this test because it requires timout support from persister.");
             }
         }
+
+        public static void RequiresOptimisticConcurrencySupport(this IPersistenceTestsConfiguration configuration)
+        {
+            if (configuration.SupportsPessimisticConcurrency)
+            {
+                Assert.Ignore("Ignoring this test because it requires optimistic concurrency support from persister.");
+            }
+        }
+
+        public static void RequiresPessimisticConcurrencySupport(this IPersistenceTestsConfiguration configuration)
+        {
+            if (!configuration.SupportsPessimisticConcurrency)
+            {
+                Assert.Ignore("Ignoring this test because it requires pessimistic concurrency support from persister.");
+            }
+        }
     }
 }

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_persisting_the_same_saga_twice_in_two_sessions_on_the_same_thread.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_persisting_the_same_saga_twice_in_two_sessions_on_the_same_thread.cs
@@ -13,6 +13,8 @@ namespace NServiceBus.Persistence.ComponentTests
         [Test]
         public async Task Save_process_is_repeatable()
         {
+            configuration.RequiresOptimisticConcurrencySupport();
+
             var correlationPropertyData = Guid.NewGuid().ToString();
             var saga = new TestSagaData {SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow};
 

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_retrieving_same_saga_on_different_threads.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_retrieving_same_saga_on_different_threads.cs
@@ -12,6 +12,8 @@ namespace NServiceBus.Persistence.ComponentTests
         [Test]
         public async Task Save_should_fail_when_data_changes_between_read_and_update_on_same_thread()
         {
+            configuration.RequiresOptimisticConcurrencySupport();
+
             var correlationPropertyData = Guid.NewGuid().ToString();
 
             var persister = configuration.SagaStorage;

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_retrieving_same_saga_on_the_same_thread.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_retrieving_same_saga_on_the_same_thread.cs
@@ -13,6 +13,8 @@ namespace NServiceBus.Persistence.ComponentTests
         [Test]
         public async Task Save_should_fail_when_data_changes_between_read_and_update()
         {
+            configuration.RequiresOptimisticConcurrencySupport();
+
             var correlationPropertyData = Guid.NewGuid().ToString();
 
             var persister = configuration.SagaStorage;

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_worker_tries_to_complete_saga_update_by_another.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_worker_tries_to_complete_saga_update_by_another.cs
@@ -13,6 +13,8 @@ namespace NServiceBus.Persistence.ComponentTests
         [Test]
         public async Task Should_fail()
         {
+            configuration.RequiresOptimisticConcurrencySupport();
+
             var correlationPropertyData = Guid.NewGuid().ToString();
             var saga = new TestSagaData {SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow};
 

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_worker_tries_to_complete_saga_update_by_another_optimistic.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_worker_tries_to_complete_saga_update_by_another_optimistic.cs
@@ -8,7 +8,7 @@ namespace NServiceBus.Persistence.ComponentTests
     using NUnit.Framework;
 
     [TestFixture]
-    public class When_worker_tries_to_complete_saga_update_by_another : SagaPersisterTests<TestSaga, TestSagaData>
+    public class When_worker_tries_to_complete_saga_update_by_another_optimistic : SagaPersisterTests<TestSaga, TestSagaData>
     {
         [Test]
         public async Task Should_fail()

--- a/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_worker_tries_to_complete_saga_update_by_another_pessimistic.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ComponentTests/Sagas/When_worker_tries_to_complete_saga_update_by_another_pessimistic.cs
@@ -1,0 +1,81 @@
+﻿namespace NServiceBus.Storage.MongoDB.Tests.ComponentTests.Sagas
+{
+    using NUnit.Framework;
+    using Persistence.ComponentTests;
+    using System;
+    using System.Threading.Tasks;
+
+    [TestFixture]
+    public class When_worker_tries_to_complete_saga_update_by_another_pessimistic : SagaPersisterTests<TestSaga, TestSagaData>
+    {
+        [Test]
+        public async Task Should_complete()
+        {
+            configuration.RequiresPessimisticConcurrencySupport();
+
+            var correlationPropertyData = Guid.NewGuid().ToString();
+            var saga = new TestSagaData {SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow};
+            await SaveSaga(saga);
+
+            var firstSessionDateTimeValue = DateTime.UtcNow.AddDays(-2);
+            var secondSessionDateTimeValue = DateTime.UtcNow.AddDays(-1);
+
+            var firstSessionGetDone = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var secondSessionGetDone = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var persister = configuration.SagaStorage;
+
+            async Task FirstSession()
+            {
+                var firstContent = configuration.GetContextBagForSagaStorage();
+                var firstSaveSession = await configuration.SynchronizedStorage.OpenSession(firstContent);
+                try
+                {
+                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(firstContent, saga);
+                    var record = await persister.Get<TestSagaData>(saga.Id, firstSaveSession, firstContent);
+                    firstSessionGetDone.SetResult(true);
+
+                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(firstContent, record);
+                    record.DateTimeProperty = firstSessionDateTimeValue;
+                    await persister.Update(record, firstSaveSession, firstContent);
+                    await secondSessionGetDone.Task.ConfigureAwait(false);
+                    await firstSaveSession.CompleteAsync();
+                }
+                finally
+                {
+                    firstSaveSession.Dispose();
+                }
+            }
+
+            async Task SecondSession()
+            {
+                var secondContext = configuration.GetContextBagForSagaStorage();
+                var secondSession = await configuration.SynchronizedStorage.OpenSession(secondContext);
+                try
+                {
+                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(secondContext, saga);
+
+                    await firstSessionGetDone.Task.ConfigureAwait(false);
+
+                    var recordTask = persister.Get<TestSagaData>(saga.Id, secondSession, secondContext);
+                    secondSessionGetDone.SetResult(true);
+                    var record = await recordTask.ConfigureAwait(false);
+                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(secondContext, record);
+                    record.DateTimeProperty = secondSessionDateTimeValue;
+                    await persister.Update(record, secondSession, secondContext);
+                    await secondSession.CompleteAsync();
+                }
+                finally
+                {
+                    secondSession.Dispose();
+                }
+            }
+
+            await Task.WhenAll(SecondSession(), FirstSession());
+
+            var result = await GetByCorrelationProperty(nameof(TestSagaData.SomeId), correlationPropertyData);
+
+            // MongoDB stores datetime with less precision
+            Assert.That(result.DateTimeProperty, Is.EqualTo(secondSessionDateTimeValue).Within(TimeSpan.FromMilliseconds(1)));
+        }
+    }
+}

--- a/src/NServiceBus.Storage.MongoDB.Tests/NServiceBus.Storage.MongoDB.Tests.csproj
+++ b/src/NServiceBus.Storage.MongoDB.Tests/NServiceBus.Storage.MongoDB.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/src/NServiceBus.Storage.MongoDB.Tests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/PersistenceTestsConfiguration.cs
@@ -55,6 +55,8 @@
 
         public bool SupportsTimeouts { get; } = false;
 
+        public bool SupportsPessimisticConcurrency { get; } = true;
+
         public ISagaIdGenerator SagaIdGenerator { get; }
 
         public ISagaPersister SagaStorage { get; }

--- a/src/NServiceBus.Storage.MongoDB/Outbox/MongoOutboxTransaction.cs
+++ b/src/NServiceBus.Storage.MongoDB/Outbox/MongoOutboxTransaction.cs
@@ -10,7 +10,8 @@
     {
         public MongoOutboxTransaction(IClientSessionHandle mongoSession, string databaseName, ContextBag context, Func<Type, string> collectionNamingConvention)
         {
-            StorageSession = new StorageSession(mongoSession, databaseName, context, collectionNamingConvention, false);
+            StorageSession = new StorageSession(mongoSession, databaseName, context, collectionNamingConvention, false, true);
+            StorageSession.StartTransaction();
         }
 
         public StorageSession StorageSession { get; }

--- a/src/NServiceBus.Storage.MongoDB/Outbox/MongoOutboxTransactionFactory.cs
+++ b/src/NServiceBus.Storage.MongoDB/Outbox/MongoOutboxTransactionFactory.cs
@@ -19,8 +19,6 @@
         {
             var mongoSession = await client.StartSessionAsync().ConfigureAwait(false);
 
-            mongoSession.StartTransaction(new TransactionOptions(ReadConcern.Majority, ReadPreference.Primary, WriteConcern.WMajority));
-
             return new MongoOutboxTransaction(mongoSession, databaseName, context, collectionNamingConvention);
         }
 

--- a/src/NServiceBus.Storage.MongoDB/Sagas/SagaPersister.cs
+++ b/src/NServiceBus.Storage.MongoDB/Sagas/SagaPersister.cs
@@ -68,7 +68,7 @@
         {
             var storageSession = (StorageSession)session;
 
-            var document = await storageSession.Find<TSagaData>(new BsonDocument(elementName, BsonValue.Create(elementValue))).SingleOrDefaultAsync().ConfigureAwait(false);
+            var document = await storageSession.Find<TSagaData>(new BsonDocument(elementName, BsonValue.Create(elementValue))).ConfigureAwait(false);
 
             if (document != null)
             {

--- a/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/StorageSession.cs
+++ b/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/StorageSession.cs
@@ -70,9 +70,9 @@
                     }).ConfigureAwait(false);
                     return result;
                 }
-                catch (MongoCommandException e)
+                catch (MongoCommandException e) when (useTransaction)
                 {
-                    if (useTransaction && e.HasErrorLabel("TransientTransactionError"))
+                    if (e.HasErrorLabel("TransientTransactionError"))
                     {
                         await AbortTransaction().ConfigureAwait(false);
 

--- a/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/StorageSession.cs
+++ b/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/StorageSession.cs
@@ -72,7 +72,7 @@
                 }
                 catch (MongoCommandException e)
                 {
-                    if (e.HasErrorLabel("TransientTransactionError"))
+                    if (useTransaction && e.HasErrorLabel("TransientTransactionError"))
                     {
                         await AbortTransaction().ConfigureAwait(false);
 

--- a/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/StorageSessionFactory.cs
+++ b/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/StorageSessionFactory.cs
@@ -20,12 +20,9 @@
         {
             var mongoSession = await client.StartSessionAsync().ConfigureAwait(false);
 
-            if (useTransactions)
-            {
-                mongoSession.StartTransaction(new TransactionOptions(ReadConcern.Majority, ReadPreference.Primary, WriteConcern.WMajority));
-            }
-
-            return new StorageSession(mongoSession, databaseName, contextBag, collectionNamingConvention, true);
+            var session = new StorageSession(mongoSession, databaseName, contextBag, collectionNamingConvention, true, useTransactions);
+            session.StartTransaction();
+            return session;
         }
 
         readonly IMongoClient client;


### PR DESCRIPTION
Implements pessimistic locking on the saga storage by using the `FindAndModify` API to get an early write lock on the transactions.

We have to manually handle the retry logic as due to our seam API we cannot use Mongo's callback transaction API.