### PR TITLE
Ability to cancel find operations

### DIFF
--- a/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/StorageSession.cs
+++ b/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/StorageSession.cs
@@ -65,19 +65,31 @@
 
             using (var cancellationTokenSource = new CancellationTokenSource(transactionTimeout))
             {
-                while (!cancellationTokenSource.IsCancellationRequested)
+                var token = cancellationTokenSource.Token;
+                while (!token.IsCancellationRequested)
                 {
                     try
                     {
-                        var result = await sagaCollection.FindOneAndUpdateAsync(MongoSession, filter, update, FindOneAndUpdateOptions, CancellationToken.None)
+                        var result = await sagaCollection.FindOneAndUpdateAsync(MongoSession, filter, update, FindOneAndUpdateOptions, token)
                             .ConfigureAwait(false);
                         return result;
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // no-op
                     }
                     catch (MongoCommandException e) when (WriteConflictUnderTransaction(e))
                     {
                         await AbortTransaction().ConfigureAwait(false);
 
-                        await Task.Delay(TimeSpan.FromMilliseconds(random.Next(5, 20)), CancellationToken.None).ConfigureAwait(false);
+                        try
+                        {
+                            await Task.Delay(TimeSpan.FromMilliseconds(random.Next(5, 20)), token).ConfigureAwait(false);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            continue;
+                        }
 
                         StartTransaction();
                     }

--- a/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/StorageSession.cs
+++ b/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/StorageSession.cs
@@ -76,7 +76,7 @@
                     }
                     catch (OperationCanceledException)
                     {
-                        // no-op
+                        break;
                     }
                     catch (MongoCommandException e) when (WriteConflictUnderTransaction(e))
                     {
@@ -88,7 +88,7 @@
                         }
                         catch (OperationCanceledException)
                         {
-                            continue;
+                            break;
                         }
 
                         StartTransaction();


### PR DESCRIPTION
Makes sure when the transaction timeout is due the find or the delay operation do not hang unnecessarily