### PR TITLE
Remove unused configuration properties

### DIFF
--- a/src/NServiceBus.Storage.MongoDB.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.Storage.MongoDB.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -17,10 +17,6 @@
 
         public bool SupportsFinders => false;
 
-        public bool SupportsSubscriptions => true;
-
-        public bool SupportsTimeouts => false;
-
         public bool SupportsPessimisticConcurrency => true;
 
         public ISagaIdGenerator SagaIdGenerator { get; } = new DefaultSagaIdGenerator();


### PR DESCRIPTION
leftovers from the initial persistence tests configuration that was forgotten.