### PR TITLE
Prevent exceptions when calling dispose multiple times

### DIFF
--- a/src/NServiceBus.Storage.MongoDB.Tests/SynchronizedStorage/StorageSessionTests.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/SynchronizedStorage/StorageSessionTests.cs
@@ -1,0 +1,20 @@
+﻿namespace NServiceBus.Storage.MongoDB.Tests
+{
+    using System;
+    using Extensibility;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class StorageSessionTests
+    {
+        [Test]
+        public void Should_allow_multiple_calls_to_dispose()
+        {
+            using var sessionHandle = ClientProvider.Client.StartSession();
+            var session = new StorageSession(sessionHandle, "db-name", new ContextBag(), t => t.FullName, true, TimeSpan.Zero);
+
+            Assert.DoesNotThrow(() => session.Dispose());
+            Assert.DoesNotThrow(() => session.Dispose());
+        }
+    }
+}

--- a/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/StorageSession.cs
+++ b/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/StorageSession.cs
@@ -113,6 +113,11 @@
 
         public void Dispose()
         {
+            if (disposed)
+            {
+                return;
+            }
+
             if (MongoSession.IsInTransaction)
             {
                 try
@@ -130,7 +135,10 @@
             }
 
             MongoSession.Dispose();
+            disposed = true;
         }
+
+        bool disposed;
 
         readonly IMongoDatabase database;
         readonly ContextBag contextBag;


### PR DESCRIPTION
the session might be disposed multiple times under certain circumstances (e.g. when resolving the session in a scope lifetime from DI + manually disposing via the `using` syntax). Dispose should be safe to be called multiple times but in this case it throws an exception because every call to dispose calls underlying mongo session properties which will throw once the session has been disposed.