### PR TITLE
Use saga data type to save and update sagas

### DIFF
--- a/src/NServiceBus.Storage.MongoDB.Tests/NServiceBus.Storage.MongoDB.Tests.csproj
+++ b/src/NServiceBus.Storage.MongoDB.Tests/NServiceBus.Storage.MongoDB.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <!-- DO NOT REMOVE MongoDB.Driver, it is added so that dependabot knows about version changes-->
-    <PackageReference Include="MongoDB.Driver" Version="2.18.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
     <PackageReference Include="NServiceBus" Version="8.0.3" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />

--- a/src/NServiceBus.Storage.MongoDB/NServiceBus.Storage.MongoDB.csproj
+++ b/src/NServiceBus.Storage.MongoDB/NServiceBus.Storage.MongoDB.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="[2.17.1, 3.0.0)" />
+    <PackageReference Include="MongoDB.Driver" Version="[2.19.0, 3.0.0)" />
     <PackageReference Include="NServiceBus" Version="[8.0.0, 9.0.0)" />
     <PackageReference Include="Particular.Packaging" Version="2.3.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/NServiceBus.Storage.MongoDB/Sagas/SagaPersister.cs
+++ b/src/NServiceBus.Storage.MongoDB/Sagas/SagaPersister.cs
@@ -22,7 +22,7 @@
             var storageSession = ((SynchronizedStorageSession)session).Session;
             var sagaDataType = sagaData.GetType();
 
-            var document = sagaData.ToBsonDocument();
+            var document = sagaData.ToBsonDocument(sagaDataType);
             document.Add(versionElementName, 0);
 
             await storageSession.InsertOneAsync(sagaDataType, document, cancellationToken).ConfigureAwait(false);
@@ -34,7 +34,7 @@
             var sagaDataType = sagaData.GetType();
 
             var version = storageSession.RetrieveVersion(sagaDataType);
-            var document = sagaData.ToBsonDocument().SetElement(new BsonElement(versionElementName, version + 1));
+            var document = sagaData.ToBsonDocument(sagaDataType).SetElement(new BsonElement(versionElementName, version + 1));
 
             var result = await storageSession.ReplaceOneAsync(sagaDataType, filterBuilder.Eq(idElementName, sagaData.Id) & filterBuilder.Eq(versionElementName, version), document, cancellationToken).ConfigureAwait(false);
 

--- a/src/NServiceBus.Storage.MongoDB/Sagas/SagaStorage.cs
+++ b/src/NServiceBus.Storage.MongoDB/Sagas/SagaStorage.cs
@@ -4,7 +4,6 @@ namespace NServiceBus.Storage.MongoDB
     using Features;
     using global::MongoDB.Bson;
     using global::MongoDB.Bson.Serialization;
-    using global::MongoDB.Bson.Serialization.Serializers;
     using global::MongoDB.Driver;
     using Microsoft.Extensions.DependencyInjection;
     using Sagas;
@@ -56,12 +55,6 @@ namespace NServiceBus.Storage.MongoDB
 
                     BsonClassMap.RegisterClassMap(classMap);
                 }
-
-                // Types must be explicitly mapped
-                _ = BsonSerializer.TryRegisterSerializer(sagaMetadata.SagaEntityType,
-                    new ObjectSerializer(type =>
-                        ObjectSerializer.DefaultAllowedTypes(type) ||
-                        type.FullName == sagaMetadata.SagaEntityType.FullName));
 
                 var collectionName = collectionNamingConvention(sagaMetadata.SagaEntityType);
 

--- a/src/NServiceBus.Storage.MongoDB/Sagas/SagaStorage.cs
+++ b/src/NServiceBus.Storage.MongoDB/Sagas/SagaStorage.cs
@@ -4,6 +4,7 @@ namespace NServiceBus.Storage.MongoDB
     using Features;
     using global::MongoDB.Bson;
     using global::MongoDB.Bson.Serialization;
+    using global::MongoDB.Bson.Serialization.Serializers;
     using global::MongoDB.Driver;
     using Microsoft.Extensions.DependencyInjection;
     using Sagas;
@@ -55,6 +56,12 @@ namespace NServiceBus.Storage.MongoDB
 
                     BsonClassMap.RegisterClassMap(classMap);
                 }
+
+                // Types must be explicitly mapped
+                _ = BsonSerializer.TryRegisterSerializer(sagaMetadata.SagaEntityType,
+                    new ObjectSerializer(type =>
+                        ObjectSerializer.DefaultAllowedTypes(type) ||
+                        type.FullName == sagaMetadata.SagaEntityType.FullName));
 
                 var collectionName = collectionNamingConvention(sagaMetadata.SagaEntityType);
 


### PR DESCRIPTION
Fixes https://github.com/Particular/NServiceBus.Storage.MongoDB/issues/481

This PR bumps the minimum required version of the mongodb client to 2.19 and explicitly passes the saga data type to the `ToBsonDocument` calls to make sure the `BsonClassMap` is used. With that in place the saga data types are automatically mapped either by the definition the persister has added or by the one that was added by a user. 

In theory, the code changes would also work with older versions of the client. But given v.2.18 has a security vulnerability and customers might not take an explicit dependency to the client, it is necessary to bump the client version too.