### PR TITLE
Saga persistence is not compatible with MongoDB.Driver Version 2.19 and higher

### DIFF
--- a/src/NServiceBus.Storage.MongoDB.AcceptanceTests/NServiceBus.Storage.MongoDB.AcceptanceTests.csproj
+++ b/src/NServiceBus.Storage.MongoDB.AcceptanceTests/NServiceBus.Storage.MongoDB.AcceptanceTests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.19.1" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Storage.MongoDB.NoTx.AcceptanceTests/NServiceBus.Storage.MongoDB.NoTx.AcceptanceTests.csproj
+++ b/src/NServiceBus.Storage.MongoDB.NoTx.AcceptanceTests/NServiceBus.Storage.MongoDB.NoTx.AcceptanceTests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.19.1" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Storage.MongoDB.PersistenceTests/NServiceBus.Storage.MongoDB.PersistenceTests.csproj
+++ b/src/NServiceBus.Storage.MongoDB.PersistenceTests/NServiceBus.Storage.MongoDB.PersistenceTests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="NServiceBus.PersistenceTests.Sources" Version="8.0.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.19.1" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Storage.MongoDB.Tests/NServiceBus.Storage.MongoDB.Tests.csproj
+++ b/src/NServiceBus.Storage.MongoDB.Tests/NServiceBus.Storage.MongoDB.Tests.csproj
@@ -11,14 +11,13 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-    <!-- DO NOT REMOVE MongoDB.Driver, it is added so that dependabot knows about version changes-->
-    <PackageReference Include="MongoDB.Driver" Version="2.17.1" />
-    <PackageReference Include="NServiceBus" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.19.1" />
+    <PackageReference Include="NServiceBus" Version="8.0.3" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Particular.Approvals" Version="0.3.0" />
-    <PackageReference Include="PublicApiGenerator" Version="10.3.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="Particular.Approvals" Version="0.4.1" />
+    <PackageReference Include="PublicApiGenerator" Version="11.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Storage.MongoDB.TransactionalSession.AcceptanceTests/NServiceBus.Storage.MongoDB.TransactionalSession.AcceptanceTests.csproj
+++ b/src/NServiceBus.Storage.MongoDB.TransactionalSession.AcceptanceTests/NServiceBus.Storage.MongoDB.TransactionalSession.AcceptanceTests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="NServiceBus.TransactionalSession" Version="2.0.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.19.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Storage.MongoDB/NServiceBus.Storage.MongoDB.csproj
+++ b/src/NServiceBus.Storage.MongoDB/NServiceBus.Storage.MongoDB.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="MongoDB.Driver" Version="[2.17.1, 3.0.0)" />
-    <PackageReference Include="NServiceBus" Version="[8.0.0, 9)" />
-    <PackageReference Include="Particular.Packaging" Version="2.2.0" PrivateAssets="All" />
+    <PackageReference Include="NServiceBus" Version="[8.0.0, 9.0.0)" />
+    <PackageReference Include="Particular.Packaging" Version="2.3.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Storage.MongoDB/Sagas/SagaPersister.cs
+++ b/src/NServiceBus.Storage.MongoDB/Sagas/SagaPersister.cs
@@ -22,7 +22,7 @@
             var storageSession = ((SynchronizedStorageSession)session).Session;
             var sagaDataType = sagaData.GetType();
 
-            var document = sagaData.ToBsonDocument();
+            var document = sagaData.ToBsonDocument(sagaDataType);
             document.Add(versionElementName, 0);
 
             await storageSession.InsertOneAsync(sagaDataType, document, cancellationToken).ConfigureAwait(false);
@@ -34,7 +34,7 @@
             var sagaDataType = sagaData.GetType();
 
             var version = storageSession.RetrieveVersion(sagaDataType);
-            var document = sagaData.ToBsonDocument().SetElement(new BsonElement(versionElementName, version + 1));
+            var document = sagaData.ToBsonDocument(sagaDataType).SetElement(new BsonElement(versionElementName, version + 1));
 
             var result = await storageSession.ReplaceOneAsync(sagaDataType, filterBuilder.Eq(idElementName, sagaData.Id) & filterBuilder.Eq(versionElementName, version), document, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
Backport of https://github.com/Particular/NServiceBus.Storage.MongoDB/pull/482 to `release-3.0`