### PR TITLE
Use native pubsub for tests

### DIFF
--- a/src/NServiceBus.Storage.MongoDB.AcceptanceTests/TestSuiteConstraints.cs
+++ b/src/NServiceBus.Storage.MongoDB.AcceptanceTests/TestSuiteConstraints.cs
@@ -8,7 +8,7 @@
 
         public bool SupportsCrossQueueTransactions => true;
 
-        public bool SupportsNativePubSub => false;
+        public bool SupportsNativePubSub => true;
 
         public bool SupportsNativeDeferral => true;
 

--- a/src/NServiceBus.Storage.MongoDB.NoTx.AcceptanceTests/TestSuiteConstraints.cs
+++ b/src/NServiceBus.Storage.MongoDB.NoTx.AcceptanceTests/TestSuiteConstraints.cs
@@ -8,7 +8,7 @@
 
         public bool SupportsCrossQueueTransactions => true;
 
-        public bool SupportsNativePubSub => false;
+        public bool SupportsNativePubSub => true;
 
         public bool SupportsNativeDeferral => true;
 


### PR DESCRIPTION
To make sure that outbox works as expected when there are duplicate message ids for subscriber endpoints