### PR TITLE
Upgrade to MongoDb.Driver v3 with using GuidSerialization standard

### DIFF
--- a/src/NServiceBus.Storage.MongoDB.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.Storage.MongoDB.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -4,6 +4,9 @@
     using System.Globalization;
     using System.Threading;
     using System.Threading.Tasks;
+    using MongoDB.Bson;
+    using MongoDB.Bson.Serialization;
+    using MongoDB.Bson.Serialization.Serializers;
     using MongoDB.Driver;
     using NServiceBus.Outbox;
     using NServiceBus.Sagas;
@@ -31,6 +34,8 @@
 
         public async Task Configure(CancellationToken cancellationToken = default)
         {
+            BsonSerializer.TryRegisterSerializer(new GuidSerializer(GuidRepresentation.Standard));
+
             var containerConnectionString = Environment.GetEnvironmentVariable("NServiceBusStorageMongoDB_ConnectionString");
             client = string.IsNullOrWhiteSpace(containerConnectionString) ? new MongoClient() : new MongoClient(containerConnectionString);
 

--- a/src/NServiceBus.Storage.MongoDB.Tests/ClientProvider.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ClientProvider.cs
@@ -1,6 +1,9 @@
 ﻿namespace NServiceBus.Storage.MongoDB.Tests
 {
     using System;
+    using global::MongoDB.Bson;
+    using global::MongoDB.Bson.Serialization;
+    using global::MongoDB.Bson.Serialization.Serializers;
     using global::MongoDB.Driver;
 
     static class ClientProvider
@@ -11,6 +14,7 @@
             {
                 if (client == null)
                 {
+                    BsonSerializer.TryRegisterSerializer(new GuidSerializer(GuidRepresentation.Standard));
                     var containerConnectionString = Environment.GetEnvironmentVariable("NServiceBusStorageMongoDB_ConnectionString");
 
                     client = string.IsNullOrWhiteSpace(containerConnectionString) ? new MongoClient() : new MongoClient(containerConnectionString);

--- a/src/NServiceBus.Storage.MongoDB/MongoPersistence.cs
+++ b/src/NServiceBus.Storage.MongoDB/MongoPersistence.cs
@@ -2,6 +2,9 @@
 {
     using System;
     using Features;
+    using MongoDB.Bson;
+    using MongoDB.Bson.Serialization;
+    using MongoDB.Bson.Serialization.Serializers;
     using MongoDB.Driver;
     using Persistence;
     using Storage.MongoDB;
@@ -16,6 +19,8 @@
         /// </summary>
         public MongoPersistence()
         {
+            BsonSerializer.TryRegisterSerializer(new GuidSerializer(GuidRepresentation.Standard));
+
             Defaults(s =>
             {
                 s.SetDefault(SettingsKeys.MongoClient, () =>

--- a/src/NServiceBus.Storage.MongoDB/NServiceBus.Storage.MongoDB.csproj
+++ b/src/NServiceBus.Storage.MongoDB/NServiceBus.Storage.MongoDB.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.2.1" />
     <PackageReference Include="NServiceBus" Version="9.2.3" />
     <PackageReference Include="Particular.Packaging" Version="4.2.2" PrivateAssets="All" />
   </ItemGroup>

--- a/src/NServiceBus.Storage.MongoDB/Sagas/SagaPersister.cs
+++ b/src/NServiceBus.Storage.MongoDB/Sagas/SagaPersister.cs
@@ -68,8 +68,11 @@
         async Task<TSagaData> GetSagaData<TSagaData>(string elementName, object elementValue, ISynchronizedStorageSession session, CancellationToken cancellationToken)
         {
             var storageSession = ((SynchronizedStorageSession)session).Session;
+            var elementValueBsonRepresentation = elementValue is Guid guid
+                ? new BsonBinaryData(guid, GuidRepresentation.Standard)
+                : BsonValue.Create(elementValue);
 
-            var document = await storageSession.Find<TSagaData>(new BsonDocument(elementName, BsonValue.Create(elementValue)), cancellationToken).ConfigureAwait(false);
+            var document = await storageSession.Find<TSagaData>(new BsonDocument(elementName, elementValueBsonRepresentation), cancellationToken).ConfigureAwait(false);
 
             if (document != null)
             {


### PR DESCRIPTION
This PR is a supplement to #751. The mentioned dependabot PR missed fixes about GuidSerialization handling. That is the main reason for it's failure. I tried to address the missing parts in the PR especially around BsonValue handling during the fetch of a saga with a key. 

I couldn't find a better&proper place in the project to centralize BsonSerializer configuration. For Acceptance tests adding BsonSerializer settings to MongoPersistence is enough. But for the rest of the test, it has to be configured specifically for each test project. I chose to apply `TryRegisterSerializer` method to prevent any errors if hosting application already adds a GuidSerializer.

#691 #108 