### PR TITLE
Add client provider support

### DIFF
--- a/src/NServiceBus.Storage.MongoDB.AcceptanceTests/When_custom_provider_registered.cs
+++ b/src/NServiceBus.Storage.MongoDB.AcceptanceTests/When_custom_provider_registered.cs
@@ -1,0 +1,83 @@
+﻿namespace NServiceBus.AcceptanceTests;
+
+using System;
+using System.Threading.Tasks;
+using AcceptanceTesting;
+using EndpointTemplates;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
+using NUnit.Framework;
+using Storage.MongoDB;
+
+public class When_custom_provider_registered : NServiceBusAcceptanceTest
+{
+    [Test]
+    public async Task Should_be_used()
+    {
+        Context context = await Scenario.Define<Context>()
+            .WithEndpoint<EndpointWithCustomProvider>(b => b.When(session => session.SendLocal(new StartSaga1 { DataId = Guid.NewGuid() })))
+            .Done(c => c.SagaReceivedMessage)
+            .Run();
+
+        Assert.That(context.ProviderWasCalled, Is.True);
+    }
+
+    public class Context : ScenarioContext
+    {
+        public bool SagaReceivedMessage { get; set; }
+        public bool ProviderWasCalled { get; set; }
+    }
+
+    public class EndpointWithCustomProvider : EndpointConfigurationBuilder
+    {
+        public EndpointWithCustomProvider() =>
+            EndpointSetup<DefaultServer>(config =>
+            {
+                config.RegisterComponents(c =>
+                    c.AddSingleton<IMongoClientProvider>(b => new CustomProvider(b.GetService<Context>())));
+            });
+
+        public class JustASaga(Context testContext) : Saga<JustASagaData>, IAmStartedByMessages<StartSaga1>
+        {
+            public Task Handle(StartSaga1 message, IMessageHandlerContext context)
+            {
+                Data.DataId = message.DataId;
+                testContext.SagaReceivedMessage = true;
+                MarkAsComplete();
+                return Task.CompletedTask;
+            }
+
+            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<JustASagaData> mapper) => mapper.ConfigureMapping<StartSaga1>(m => m.DataId).ToSaga(s => s.DataId);
+        }
+
+        public class CustomProvider(Context testContext) : IMongoClientProvider
+        {
+            public IMongoClient Client
+            {
+                get
+                {
+                    if (field is not null)
+                    {
+                        return field;
+                    }
+
+                    var containerConnectionString = Environment.GetEnvironmentVariable("NServiceBusStorageMongoDB_ConnectionString");
+
+                    field = string.IsNullOrWhiteSpace(containerConnectionString) ? new MongoClient() : new MongoClient(containerConnectionString);
+                    testContext.ProviderWasCalled = true;
+                    return field;
+                }
+            }
+        }
+
+        public class JustASagaData : ContainSagaData
+        {
+            public virtual Guid DataId { get; set; }
+        }
+    }
+
+    public class StartSaga1 : ICommand
+    {
+        public Guid DataId { get; set; }
+    }
+}

--- a/src/NServiceBus.Storage.MongoDB.AcceptanceTests/When_custom_provider_registered.cs
+++ b/src/NServiceBus.Storage.MongoDB.AcceptanceTests/When_custom_provider_registered.cs
@@ -1,6 +1,9 @@
-﻿namespace NServiceBus.AcceptanceTests;
+﻿#nullable enable
+
+namespace NServiceBus.AcceptanceTests;
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using AcceptanceTesting;
 using EndpointTemplates;
@@ -34,7 +37,7 @@ public class When_custom_provider_registered : NServiceBusAcceptanceTest
             EndpointSetup<DefaultServer>(config =>
             {
                 config.RegisterComponents(c =>
-                    c.AddSingleton<IMongoClientProvider>(b => new CustomProvider(b.GetService<Context>())));
+                    c.AddSingleton<IMongoClientProvider>(b => new CustomProvider(b.GetRequiredService<Context>())));
             });
 
         public class JustASaga(Context testContext) : Saga<JustASagaData>, IAmStartedByMessages<StartSaga1>
@@ -52,6 +55,7 @@ public class When_custom_provider_registered : NServiceBusAcceptanceTest
 
         public class CustomProvider(Context testContext) : IMongoClientProvider
         {
+            [field: AllowNull, MaybeNull]
             public IMongoClient Client
             {
                 get

--- a/src/NServiceBus.Storage.MongoDB.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.Storage.MongoDB.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
-using MongoDB.Driver;
 using NServiceBus.Outbox;
 using NServiceBus.Sagas;
 using Persistence;
@@ -40,15 +39,9 @@ public partial class PersistenceTestsConfiguration
         BsonSerializer.TryRegisterSerializer(new GuidSerializer(GuidRepresentation.Standard));
 
         var memberMapCache = new MemberMapCache();
-        var databaseSettings = new MongoDatabaseSettings
-        {
-            ReadConcern = ReadConcern.Majority,
-            ReadPreference = ReadPreference.Primary,
-            WriteConcern = WriteConcern.WMajority
-        };
 
         SagaStorageFeature.RegisterSagaEntityClassMappings(SagaMetadataCollection, memberMapCache);
-        await SagaInstaller.CreateInfrastructureForSagaDataTypes(ClientProvider.Client, databaseSettings, memberMapCache, databaseName,
+        await SagaInstaller.CreateInfrastructureForSagaDataTypes(ClientProvider.Client, MongoPersistence.DefaultDatabaseSettings, memberMapCache, databaseName,
             MongoPersistence.DefaultCollectionNamingConvention, MongoPersistence.DefaultCollectionSettings, SagaMetadataCollection, cancellationToken);
 
         SagaStorage = new SagaPersister(SagaPersister.DefaultVersionElementName, memberMapCache);
@@ -60,7 +53,7 @@ public partial class PersistenceTestsConfiguration
         OutboxStorageFeature.RegisterOutboxClassMappings();
         await OutboxInstaller.CreateInfrastructureForOutboxTypes(ClientProvider.Client, databaseName, MongoPersistence.DefaultDatabaseSettings, MongoPersistence.DefaultCollectionNamingConvention, MongoPersistence.DefaultCollectionSettings, TimeSpan.FromDays(7), cancellationToken);
 
-        OutboxStorage = new OutboxPersister(ClientProvider.Client, databaseName, MongoPersistence.DefaultCollectionNamingConvention);
+        OutboxStorage = new OutboxPersister(ClientProvider.Client, databaseName, MongoPersistence.DefaultDatabaseSettings, MongoPersistence.DefaultCollectionNamingConvention, MongoPersistence.DefaultCollectionSettings);
     }
 
     public async Task Cleanup(CancellationToken cancellationToken = default) =>

--- a/src/NServiceBus.Storage.MongoDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Storage.MongoDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -28,6 +28,10 @@ namespace NServiceBus
 }
 namespace NServiceBus.Storage.MongoDB
 {
+    public interface IMongoClientProvider
+    {
+        MongoDB.Driver.IMongoClient Client { get; }
+    }
     public interface IMongoSynchronizedStorageSession
     {
         MongoDB.Driver.IClientSessionHandle? MongoSession { get; }

--- a/src/NServiceBus.Storage.MongoDB.Tests/Outbox/OutboxTestsConfiguration.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/Outbox/OutboxTestsConfiguration.cs
@@ -41,7 +41,7 @@ public class OutboxTestsConfiguration
         await OutboxInstaller.CreateInfrastructureForOutboxTypes(ClientProvider.Client, DatabaseName, MongoPersistence.DefaultDatabaseSettings, CollectionNamingConvention,
             MongoPersistence.DefaultCollectionSettings, TimeSpan.FromHours(1));
 
-        OutboxStorage = new OutboxPersister(ClientProvider.Client, DatabaseName, CollectionNamingConvention);
+        OutboxStorage = new OutboxPersister(ClientProvider.Client, DatabaseName, MongoPersistence.DefaultDatabaseSettings, CollectionNamingConvention, MongoPersistence.DefaultCollectionSettings);
     }
 
     public async Task Cleanup() => await ClientProvider.Client.DropDatabaseAsync(DatabaseName);

--- a/src/NServiceBus.Storage.MongoDB.Tests/SubscriptionStorageTests.cs
+++ b/src/NServiceBus.Storage.MongoDB.Tests/SubscriptionStorageTests.cs
@@ -18,12 +18,10 @@ class SubscriptionStorageTests
     {
         DatabaseName = "Test_" + DateTime.UtcNow.Ticks.ToString(CultureInfo.InvariantCulture);
 
-        var subscriptionCollection = ClientProvider.Client.GetDatabase(DatabaseName, MongoPersistence.DefaultDatabaseSettings)
-            .GetCollection<EventSubscription>("eventsubscriptions", MongoPersistence.DefaultCollectionSettings);
-
         await SubscriptionInstaller.CreateInfrastructureForSubscriptionTypes(ClientProvider.Client, MongoPersistence.DefaultDatabaseSettings, DatabaseName, MongoPersistence.DefaultCollectionSettings, _ => "eventsubscriptions");
 
-        var subscriptionPersister = new SubscriptionPersister(subscriptionCollection);
+        var subscriptionPersister = new SubscriptionPersister(ClientProvider.Client, DatabaseName, MongoPersistence.DefaultDatabaseSettings,
+            _ => "eventsubscriptions", MongoPersistence.DefaultCollectionSettings);
         storage = subscriptionPersister;
     }
 

--- a/src/NServiceBus.Storage.MongoDB/Configuration/DefaultMongoClientProvider.cs
+++ b/src/NServiceBus.Storage.MongoDB/Configuration/DefaultMongoClientProvider.cs
@@ -1,0 +1,17 @@
+namespace NServiceBus.Storage.MongoDB;
+
+using System.Diagnostics.CodeAnalysis;
+using global::MongoDB.Driver;
+
+sealed class DefaultMongoClientProvider : IMongoClientProvider
+{
+    [field: AllowNull, MaybeNull]
+    public IMongoClient Client
+    {
+        get
+        {
+            field ??= new MongoClient();
+            return field;
+        }
+    }
+}

--- a/src/NServiceBus.Storage.MongoDB/Configuration/IMongoClientProvider.cs
+++ b/src/NServiceBus.Storage.MongoDB/Configuration/IMongoClientProvider.cs
@@ -1,0 +1,17 @@
+namespace NServiceBus.Storage.MongoDB;
+
+using global::MongoDB.Driver;
+
+/// <summary>
+/// Provides a mongo client via dependency injection. A custom implementation can be registered on the container and will be picked up by the persistence.
+/// <remarks>
+/// The client provided will not be disposed by the persistence. It is the responsibility of the provider to take care of proper resource disposal if necessary.
+/// </remarks>
+/// </summary>
+public interface IMongoClientProvider
+{
+    /// <summary>
+    /// The mongo client to use.
+    /// </summary>
+    IMongoClient Client { get; }
+}

--- a/src/NServiceBus.Storage.MongoDB/Configuration/MongoClientProvidedByConfiguration.cs
+++ b/src/NServiceBus.Storage.MongoDB/Configuration/MongoClientProvidedByConfiguration.cs
@@ -1,0 +1,8 @@
+namespace NServiceBus.Storage.MongoDB;
+
+using global::MongoDB.Driver;
+
+class MongoClientProvidedByConfiguration(IMongoClient client) : IMongoClientProvider
+{
+    public IMongoClient Client { get; } = client;
+}

--- a/src/NServiceBus.Storage.MongoDB/Configuration/MongoSettingsExtensions.cs
+++ b/src/NServiceBus.Storage.MongoDB/Configuration/MongoSettingsExtensions.cs
@@ -19,7 +19,7 @@ public static class MongoSettingsExtensions
         ArgumentNullException.ThrowIfNull(persistenceExtensions);
         ArgumentNullException.ThrowIfNull(mongoClient);
 
-        persistenceExtensions.GetSettings().Set(SettingsKeys.MongoClient, () => mongoClient);
+        persistenceExtensions.GetSettings().Set<IMongoClientProvider>(new MongoClientProvidedByConfiguration(mongoClient));
         return persistenceExtensions;
     }
 

--- a/src/NServiceBus.Storage.MongoDB/Configuration/SettingsKeys.cs
+++ b/src/NServiceBus.Storage.MongoDB/Configuration/SettingsKeys.cs
@@ -6,7 +6,6 @@ static class SettingsKeys
     public const string VersionElementName = baseName + nameof(VersionElementName);
     public const string CollectionNamingConvention = baseName + nameof(CollectionNamingConvention);
     public const string DatabaseName = baseName + nameof(DatabaseName);
-    public const string MongoClient = baseName + nameof(MongoClient);
     public const string UseTransactions = baseName + nameof(UseTransactions);
     public const string TimeToKeepOutboxDeduplicationData = baseName + nameof(TimeToKeepOutboxDeduplicationData);
 }

--- a/src/NServiceBus.Storage.MongoDB/MongoPersistence.cs
+++ b/src/NServiceBus.Storage.MongoDB/MongoPersistence.cs
@@ -26,12 +26,7 @@ public class MongoPersistence : PersistenceDefinition
             // Can't do much earlier due to static nature of class mappings and serialization extensions.
             SafeRegisterDefaultGuidSerializer();
 
-            s.SetDefault(SettingsKeys.MongoClient, static () =>
-            {
-                defaultClient ??= new MongoClient();
-
-                return defaultClient;
-            });
+            s.SetDefault<IMongoClientProvider>(new DefaultMongoClientProvider());
 
             s.SetDefault(SettingsKeys.DatabaseName, s.EndpointName());
 
@@ -97,6 +92,4 @@ public class MongoPersistence : PersistenceDefinition
 
     internal static readonly TimeSpan DefaultTransactionTimeout = TimeSpan.FromSeconds(60);
     internal static readonly Func<Type, string> DefaultCollectionNamingConvention = type => type.Name.ToLower();
-
-    static IMongoClient? defaultClient;
 }

--- a/src/NServiceBus.Storage.MongoDB/Outbox/OutboxInstaller.cs
+++ b/src/NServiceBus.Storage.MongoDB/Outbox/OutboxInstaller.cs
@@ -4,17 +4,19 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Features;
 using global::MongoDB.Bson;
 using global::MongoDB.Driver;
 using Installation;
+using Microsoft.Extensions.DependencyInjection;
 using Settings;
 
-sealed class OutboxInstaller(IReadOnlySettings settings, IMongoClientProvider clientProvider) : INeedToInstallSomething
+sealed class OutboxInstaller(IReadOnlySettings settings, IServiceProvider serviceProvider) : INeedToInstallSomething
 {
     public async Task Install(string identity, CancellationToken cancellationToken = default)
     {
         var installerSettings = settings.Get<InstallerSettings>();
-        if (installerSettings.Disabled)
+        if (installerSettings.Disabled || !settings.IsFeatureActive(typeof(OutboxStorage)))
         {
             return;
         }
@@ -29,7 +31,10 @@ sealed class OutboxInstaller(IReadOnlySettings settings, IMongoClientProvider cl
             timeToKeepOutboxDeduplicationData = DefaultTimeToKeepOutboxDeduplicationData;
         }
 
-        await CreateInfrastructureForOutboxTypes(clientProvider.Client, databaseName, databaseSettings, collectionNamingConvention, collectionSettings, timeToKeepOutboxDeduplicationData, cancellationToken)
+        // We have to resolve the client provider here because at the time of the creation of the installer the provider might not be registered yet.
+        var clientProvider = serviceProvider.GetRequiredService<IMongoClientProvider>();
+
+        await CreateInfrastructureForOutboxTypes(clientProvider!.Client, databaseName, databaseSettings, collectionNamingConvention, collectionSettings, timeToKeepOutboxDeduplicationData, cancellationToken)
             .ConfigureAwait(false);
     }
 

--- a/src/NServiceBus.Storage.MongoDB/Outbox/OutboxInstaller.cs
+++ b/src/NServiceBus.Storage.MongoDB/Outbox/OutboxInstaller.cs
@@ -9,12 +9,12 @@ using global::MongoDB.Driver;
 using Installation;
 using Settings;
 
-sealed class OutboxInstaller(IReadOnlySettings settings) : INeedToInstallSomething
+sealed class OutboxInstaller(IReadOnlySettings settings, IMongoClientProvider clientProvider) : INeedToInstallSomething
 {
     public async Task Install(string identity, CancellationToken cancellationToken = default)
     {
         var installerSettings = settings.Get<InstallerSettings>();
-        if (installerSettings.Disabled || !settings.TryGet<Func<IMongoClient>>(SettingsKeys.MongoClient, out Func<IMongoClient>? client))
+        if (installerSettings.Disabled)
         {
             return;
         }
@@ -29,7 +29,7 @@ sealed class OutboxInstaller(IReadOnlySettings settings) : INeedToInstallSomethi
             timeToKeepOutboxDeduplicationData = DefaultTimeToKeepOutboxDeduplicationData;
         }
 
-        await CreateInfrastructureForOutboxTypes(client(), databaseName, databaseSettings, collectionNamingConvention, collectionSettings, timeToKeepOutboxDeduplicationData, cancellationToken)
+        await CreateInfrastructureForOutboxTypes(clientProvider.Client, databaseName, databaseSettings, collectionNamingConvention, collectionSettings, timeToKeepOutboxDeduplicationData, cancellationToken)
             .ConfigureAwait(false);
     }
 

--- a/src/NServiceBus.Storage.MongoDB/Outbox/OutboxPersister.cs
+++ b/src/NServiceBus.Storage.MongoDB/Outbox/OutboxPersister.cs
@@ -10,19 +10,11 @@ using Outbox;
 
 class OutboxPersister : IOutboxStorage
 {
-    public OutboxPersister(IMongoClient client, string databaseName, Func<Type, string> collectionNamingConvention)
+    public OutboxPersister(IMongoClient client, string databaseName, MongoDatabaseSettings databaseSettings, Func<Type, string> collectionNamingConvention, MongoCollectionSettings collectionSettings)
     {
-        outboxTransactionFactory = new MongoOutboxTransactionFactory(client, databaseName, collectionNamingConvention,
-            MongoPersistence.DefaultTransactionTimeout);
+        outboxTransactionFactory = new MongoOutboxTransactionFactory(client, databaseName, collectionNamingConvention, MongoPersistence.DefaultTransactionTimeout);
 
-        var collectionSettings = new MongoCollectionSettings
-        {
-            ReadConcern = ReadConcern.Majority,
-            ReadPreference = ReadPreference.Primary,
-            WriteConcern = WriteConcern.WMajority
-        };
-
-        outboxRecordCollection = client.GetDatabase(databaseName)
+        outboxRecordCollection = client.GetDatabase(databaseName, databaseSettings)
             .GetCollection<OutboxRecord>(collectionNamingConvention(typeof(OutboxRecord)), collectionSettings);
     }
 

--- a/src/NServiceBus.Storage.MongoDB/Sagas/SagaInstaller.cs
+++ b/src/NServiceBus.Storage.MongoDB/Sagas/SagaInstaller.cs
@@ -9,12 +9,12 @@ using Installation;
 using Sagas;
 using Settings;
 
-sealed class SagaInstaller(IReadOnlySettings settings) : INeedToInstallSomething
+sealed class SagaInstaller(IReadOnlySettings settings, IMongoClientProvider clientProvider) : INeedToInstallSomething
 {
     public async Task Install(string identity, CancellationToken cancellationToken = default)
     {
         var installerSettings = settings.Get<InstallerSettings>();
-        if (installerSettings.Disabled || !settings.TryGet<Func<IMongoClient>>(SettingsKeys.MongoClient, out Func<IMongoClient>? client))
+        if (installerSettings.Disabled)
         {
             return;
         }
@@ -26,7 +26,7 @@ sealed class SagaInstaller(IReadOnlySettings settings) : INeedToInstallSomething
         var collectionSettings = settings.Get<MongoCollectionSettings>();
         var memberMapCache = settings.Get<MemberMapCache>();
 
-        await CreateInfrastructureForSagaDataTypes(client(), databaseSettings, memberMapCache, databaseName, collectionNamingConvention, collectionSettings, sagaMetadataCollection, cancellationToken)
+        await CreateInfrastructureForSagaDataTypes(clientProvider.Client, databaseSettings, memberMapCache, databaseName, collectionNamingConvention, collectionSettings, sagaMetadataCollection, cancellationToken)
             .ConfigureAwait(false);
     }
 

--- a/src/NServiceBus.Storage.MongoDB/Subscriptions/SubscriptionInstaller.cs
+++ b/src/NServiceBus.Storage.MongoDB/Subscriptions/SubscriptionInstaller.cs
@@ -3,16 +3,18 @@ namespace NServiceBus.Storage.MongoDB;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Features;
 using global::MongoDB.Driver;
 using Installation;
+using Microsoft.Extensions.DependencyInjection;
 using Settings;
 
-sealed class SubscriptionInstaller(IReadOnlySettings settings, IMongoClientProvider clientProvider) : INeedToInstallSomething
+sealed class SubscriptionInstaller(IReadOnlySettings settings, IServiceProvider serviceProvider) : INeedToInstallSomething
 {
     public async Task Install(string identity, CancellationToken cancellationToken = default)
     {
         var installerSettings = settings.Get<InstallerSettings>();
-        if (installerSettings.Disabled)
+        if (installerSettings.Disabled || !settings.IsFeatureActive(typeof(SubscriptionStorage)))
         {
             return;
         }
@@ -21,6 +23,9 @@ sealed class SubscriptionInstaller(IReadOnlySettings settings, IMongoClientProvi
         var databaseSettings = settings.Get<MongoDatabaseSettings>();
         var collectionSettings = settings.Get<MongoCollectionSettings>();
         var collectionNamingConvention = settings.Get<Func<Type, string>>(SettingsKeys.CollectionNamingConvention);
+
+        // We have to resolve the client provider here because at the time of the creation of the installer the provider might not be registered yet.
+        var clientProvider = serviceProvider.GetRequiredService<IMongoClientProvider>();
 
         await CreateInfrastructureForSubscriptionTypes(clientProvider.Client, databaseSettings, databaseName, collectionSettings, collectionNamingConvention, cancellationToken)
             .ConfigureAwait(false);

--- a/src/NServiceBus.Storage.MongoDB/Subscriptions/SubscriptionInstaller.cs
+++ b/src/NServiceBus.Storage.MongoDB/Subscriptions/SubscriptionInstaller.cs
@@ -7,12 +7,12 @@ using global::MongoDB.Driver;
 using Installation;
 using Settings;
 
-sealed class SubscriptionInstaller(IReadOnlySettings settings) : INeedToInstallSomething
+sealed class SubscriptionInstaller(IReadOnlySettings settings, IMongoClientProvider clientProvider) : INeedToInstallSomething
 {
     public async Task Install(string identity, CancellationToken cancellationToken = default)
     {
         var installerSettings = settings.Get<InstallerSettings>();
-        if (installerSettings.Disabled || !settings.TryGet<Func<IMongoClient>>(SettingsKeys.MongoClient, out Func<IMongoClient>? client))
+        if (installerSettings.Disabled)
         {
             return;
         }
@@ -22,7 +22,7 @@ sealed class SubscriptionInstaller(IReadOnlySettings settings) : INeedToInstallS
         var collectionSettings = settings.Get<MongoCollectionSettings>();
         var collectionNamingConvention = settings.Get<Func<Type, string>>(SettingsKeys.CollectionNamingConvention);
 
-        await CreateInfrastructureForSubscriptionTypes(client(), databaseSettings, databaseName, collectionSettings, collectionNamingConvention, cancellationToken)
+        await CreateInfrastructureForSubscriptionTypes(clientProvider.Client, databaseSettings, databaseName, collectionSettings, collectionNamingConvention, cancellationToken)
             .ConfigureAwait(false);
     }
 

--- a/src/NServiceBus.Storage.MongoDB/Subscriptions/SubscriptionStorage.cs
+++ b/src/NServiceBus.Storage.MongoDB/Subscriptions/SubscriptionStorage.cs
@@ -4,6 +4,7 @@ using System;
 using Features;
 using global::MongoDB.Driver;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Unicast.Subscriptions.MessageDrivenSubscriptions;
 
 class SubscriptionStorage : Feature
@@ -12,6 +13,8 @@ class SubscriptionStorage : Feature
 
     protected override void Setup(FeatureConfigurationContext context)
     {
+        context.Services.TryAddSingleton(context.Settings.Get<IMongoClientProvider>());
+
         var databaseName = context.Settings.Get<string>(SettingsKeys.DatabaseName);
         var collectionNamingConvention = context.Settings.Get<Func<Type, string>>(SettingsKeys.CollectionNamingConvention);
         var databaseSettings = context.Settings.Get<MongoDatabaseSettings>();

--- a/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/SynchronizedStorage.cs
+++ b/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/SynchronizedStorage.cs
@@ -1,10 +1,12 @@
 ﻿namespace NServiceBus.Storage.MongoDB;
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Features;
-using global::MongoDB.Driver;
 using global::MongoDB.Driver.Core.Clusters;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Persistence;
 
 class SynchronizedStorage : Feature
@@ -15,76 +17,91 @@ class SynchronizedStorage : Feature
 
     protected override void Setup(FeatureConfigurationContext context)
     {
-        var client = context.Settings.Get<Func<IMongoClient>>(SettingsKeys.MongoClient)();
+        var mongoClientProvider = context.Settings.Get<IMongoClientProvider>();
+        context.Services.TryAddSingleton(mongoClientProvider);
+
         var databaseName = context.Settings.Get<string>(SettingsKeys.DatabaseName);
-        var collectionNamingConvention =
-            context.Settings.Get<Func<Type, string>>(SettingsKeys.CollectionNamingConvention);
+        var collectionNamingConvention = context.Settings.Get<Func<Type, string>>(SettingsKeys.CollectionNamingConvention);
 
         if (!context.Settings.TryGet(SettingsKeys.UseTransactions, out bool useTransactions))
         {
             useTransactions = true;
         }
 
-        try
-        {
-            var database = client.GetDatabase(databaseName);
-
-            // perform a query to the server to make sure cluster details are loaded
-            database.ListCollectionNames();
-
-            using var session = client.StartSession();
-
-            if (useTransactions)
-            {
-                var clusterType = client.Cluster.Description.Type;
-
-                //HINT: cluster configuration check is needed as the built-in checks, executed during "StartTransaction() call,
-                //      do not detect if the cluster configuration is a supported one. Only the version ranges are validated.
-                //      Without this check, exceptions will be thrown during message processing.
-                if (clusterType is not ClusterType.ReplicaSet and not ClusterType.Sharded)
-                {
-                    throw new Exception(
-                        $"The cluster type in use is {clusterType}, but transactions are only supported on replica sets or sharded clusters. Disable support for transactions by calling 'EndpointConfiguration.UsePersistence<{nameof(MongoPersistence)}>().UseTransactions(false)'.");
-                }
-
-                try
-                {
-                    session.StartTransaction();
-                    session.AbortTransaction();
-                }
-                catch (NotSupportedException ex)
-                {
-                    throw new Exception(
-                        $"Transactions are not supported by the MongoDB server. Disable support for transactions by calling 'EndpointConfiguration.UsePersistence<{nameof(MongoPersistence)}>().UseTransactions(false)'.",
-                        ex);
-                }
-            }
-        }
-        catch (ArgumentException ex)
-        {
-            throw new Exception(
-                $"The persistence database name '{databaseName}' is invalid. Configure a valid database name by calling 'EndpointConfiguration.UsePersistence<{nameof(MongoPersistence)}>().DatabaseName(databaseName)'.",
-                ex);
-        }
-        catch (NotSupportedException ex)
-        {
-            throw new Exception(
-                "Sessions are not supported by the MongoDB server. The NServiceBus.Storage.MongoDB persistence requires MongoDB server version 3.6 or greater.",
-                ex);
-        }
-        catch (TimeoutException ex)
-        {
-            throw new Exception(
-                "Unable to connect to the MongoDB server. Check the connection settings, and verify the server is running and accessible.",
-                ex);
-        }
+        context.RegisterStartupTask(sp => new VerifyClusterDetails(sp.GetRequiredService<IMongoClientProvider>(), databaseName, useTransactions));
 
         context.Services.AddScoped<ICompletableSynchronizedStorageSession, SynchronizedStorageSession>();
-        context.Services.AddScoped(sp =>
-            (sp.GetService<ICompletableSynchronizedStorageSession>() as IMongoSynchronizedStorageSession)!);
+        context.Services.AddScoped(sp => (sp.GetService<ICompletableSynchronizedStorageSession>() as IMongoSynchronizedStorageSession)!);
+        context.Services.AddSingleton(sp => new StorageSessionFactory(sp.GetRequiredService<IMongoClientProvider>().Client, useTransactions, databaseName, collectionNamingConvention, MongoPersistence.DefaultTransactionTimeout));
+    }
 
-        context.Services.AddSingleton(
-            new StorageSessionFactory(client, useTransactions, databaseName, collectionNamingConvention,
-                MongoPersistence.DefaultTransactionTimeout));
+    class VerifyClusterDetails(IMongoClientProvider clientProvider, string databaseName, bool useTransactions) : FeatureStartupTask
+    {
+        protected override async Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var client = clientProvider.Client;
+                var database = client.GetDatabase(databaseName);
+
+                // perform a query to the server to make sure cluster details are loaded
+                await database.ListCollectionNamesAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                using var mongoSession = await client.StartSessionAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                if (useTransactions)
+                {
+                    var clusterType = client.Cluster.Description.Type;
+
+                    //HINT: cluster configuration check is needed as the built-in checks, executed during "StartTransaction() call,
+                    //      do not detect if the cluster configuration is a supported one. Only the version ranges are validated.
+                    //      Without this check, exceptions will be thrown during message processing.
+                    if (clusterType is not ClusterType.ReplicaSet and not ClusterType.Sharded)
+                    {
+                        throw new Exception(
+                            $"The cluster type in use is {clusterType}, but transactions are only supported on replica sets or sharded clusters. Disable support for transactions by calling 'EndpointConfiguration.UsePersistence<{nameof(MongoPersistence)}>().UseTransactions(false)'.");
+                    }
+
+                    try
+                    {
+                        mongoSession.StartTransaction();
+                        await mongoSession.AbortTransactionAsync(cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (NotSupportedException ex)
+                    {
+                        throw new Exception(
+                            $"Transactions are not supported by the MongoDB server. Disable support for transactions by calling 'EndpointConfiguration.UsePersistence<{nameof(MongoPersistence)}>().UseTransactions(false)'.",
+                            ex);
+                    }
+                }
+            }
+            catch (ArgumentException ex)
+            {
+                throw new Exception(
+                    $"The persistence database name '{databaseName}' is invalid. Configure a valid database name by calling 'EndpointConfiguration.UsePersistence<{nameof(MongoPersistence)}>().DatabaseName(databaseName)'.",
+                    ex);
+            }
+            catch (NotSupportedException ex)
+            {
+                throw new Exception(
+                    "Sessions are not supported by the MongoDB server. The NServiceBus.Storage.MongoDB persistence requires MongoDB server version 3.6 or greater.",
+                    ex);
+            }
+            catch (TimeoutException ex)
+            {
+                throw new Exception(
+                    "Unable to connect to the MongoDB server. Check the connection settings, and verify the server is running and accessible.",
+                    ex);
+            }
+        }
+
+        protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default)
+        {
+            if (clientProvider is DefaultMongoClientProvider { Client: { } client })
+            {
+                client.Dispose();
+            }
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/SynchronizedStorage.cs
+++ b/src/NServiceBus.Storage.MongoDB/SynchronizedStorage/SynchronizedStorage.cs
@@ -17,8 +17,8 @@ class SynchronizedStorage : Feature
 
     protected override void Setup(FeatureConfigurationContext context)
     {
-        var mongoClientProvider = context.Settings.Get<IMongoClientProvider>();
-        context.Services.TryAddSingleton(mongoClientProvider);
+        // In case the persistence is used without the SynchronizedStorage feature, we still need to try to register the IMongoClientProvider
+        context.Services.TryAddSingleton(context.Settings.Get<IMongoClientProvider>());
 
         var databaseName = context.Settings.Get<string>(SettingsKeys.DatabaseName);
         var collectionNamingConvention = context.Settings.Get<Func<Type, string>>(SettingsKeys.CollectionNamingConvention);


### PR DESCRIPTION
This PR introduces a provider concept that allows resolving the mongo client from the container. Similar functionality is already available in [DynamoDB](https://github.com/Particular/NServiceBus.Persistence.DynamoDB/blob/main/src/NServiceBus.Persistence.DynamoDB/Config/IDynamoClientProvider.cs#L11), [CosmoDB,](https://github.com/Particular/NServiceBus.Persistence.CosmosDB/blob/master/src/NServiceBus.Persistence.CosmosDB/Config/IProvideCosmosClient.cs) and [Azure Table](https://github.com/Particular/NServiceBus.Persistence.AzureTable/blob/master/src/NServiceBus.Persistence.AzureTable/Config/IProvideTableServiceClient.cs#L8).

Unfortunately the names haven't been kept consistent. In the past we used quite a few `I{VERB}` type of interfaces, which has been criticized publicly, and some attempts have been made to no longer use names like that. CosmosDB and AzureTable, if I'm not mistaken, had those names already in there, while DynamoDB persistence was created later following the "modern" nomenclature. 

This PR also makes sure that installers only run when they actually should (in case their corresponding feature is activated). 