### PR TITLE
Outbox StorageOperations pass through body directly without copying

### DIFF
--- a/src/NServiceBus.Storage.MongoDB/Outbox/StorageTransportOperation.cs
+++ b/src/NServiceBus.Storage.MongoDB/Outbox/StorageTransportOperation.cs
@@ -2,6 +2,7 @@
 
 namespace NServiceBus.Storage.MongoDB;
 
+using System;
 using System.Collections.Generic;
 
 class StorageTransportOperation
@@ -14,13 +15,13 @@ class StorageTransportOperation
     {
         MessageId = source.MessageId;
         Options = source.Options != null ? new Dictionary<string, string>(source.Options) : [];
-        Body = source.Body.ToArray();
+        Body = source.Body;
         Headers = source.Headers;
     }
 
     public string MessageId { get; set; }
     public Dictionary<string, string> Options { get; set; }
-    public byte[] Body { get; set; }
+    public ReadOnlyMemory<byte> Body { get; set; }
     public Dictionary<string, string> Headers { get; set; }
 
 


### PR DESCRIPTION
As part of going through the code base I realized the driver natively support `ReadOnlyMemory<T>`. This means we no longer have to call `ToArray()`. Unfortunately the driver [still does a `ToArray` under the covers](https://jira.mongodb.org/browse/CSHARP-5709) but this might be resolved in future versions of the driver which would then make the new code more memory efficient.

The underlying representation remains the same. Example

## Before

```json
[{"MessageId": "8136fa26-5d31-43fe-9afb-b34100c5e778", "Options": [{"k": "Destination", "v": "ADuplicateMessageArrives.DownstreamEndpoint"}], "Body": new BinData(0, "eyJUZXJtaW5hdG9yIjpmYWxzZX0="), "Headers": [{"k": "NServiceBus.MessageId", "v": "8136fa26-5d31-43fe-9afb-b34100c5e778"}, {"k": "NServiceBus.MessageIntent", "v": "Send"}, {"k": "NServiceBus.RelatedTo", "v": "57670dea-7904-4a0f-b92e-2f66e40f72aa"}, {"k": "NServiceBus.ConversationId", "v": "bda75aaa-eaf6-4640-971f-b34100c5e75f"}, {"k": "NServiceBus.CorrelationId", "v": "57670dea-7904-4a0f-b92e-2f66e40f72aa"}, {"k": "NServiceBus.ReplyToAddress", "v": "ADuplicateMessageArrives.OutboxEndpoint"}, {"k": "NServiceBus.OriginatingMachine", "v": "danielsacstudio"}, {"k": "NServiceBus.OriginatingEndpoint", "v": "ADuplicateMessageArrives.OutboxEndpoint"}, {"k": "$.diagnostics.originating.hostid", "v": "b65da644d5b5b3ee8cd445df3f7d13e9"}, {"k": "NServiceBus.ContentType", "v": "application/json"}, {"k": "NServiceBus.EnclosedMessageTypes", "v": "NServiceBus.AcceptanceTests.Outbox.When_a_duplicate_message_arrives+SendOrderAcknowledgement, NServiceBus.Storage.MongoDB.AcceptanceTests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"}, {"k": "NServiceBus.Version", "v": "10.0.0"}, {"k": "NServiceBus.TimeSent", "v": "2025-08-22 12:00:32:824299 Z"}]}]
```

# After

```json
[{"MessageId": "903e7729-eecf-4730-ab7a-b34100c516e9", "Options": [{"k": "Destination", "v": "ADuplicateMessageArrives.DownstreamEndpoint"}], "Body": new BinData(0, "eyJUZXJtaW5hdG9yIjp0cnVlfQ=="), "Headers": [{"k": "NServiceBus.MessageId", "v": "903e7729-eecf-4730-ab7a-b34100c516e9"}, {"k": "NServiceBus.MessageIntent", "v": "Send"}, {"k": "NServiceBus.RelatedTo", "v": "cf692566-98cd-4ce6-b2ef-b34100c516d6"}, {"k": "NServiceBus.ConversationId", "v": "6d9be290-f079-475d-8651-b34100c516d6"}, {"k": "NServiceBus.CorrelationId", "v": "cf692566-98cd-4ce6-b2ef-b34100c516d6"}, {"k": "NServiceBus.ReplyToAddress", "v": "ADuplicateMessageArrives.OutboxEndpoint"}, {"k": "NServiceBus.OriginatingMachine", "v": "danielsacstudio"}, {"k": "NServiceBus.OriginatingEndpoint", "v": "ADuplicateMessageArrives.OutboxEndpoint"}, {"k": "$.diagnostics.originating.hostid", "v": "b65da644d5b5b3ee8cd445df3f7d13e9"}, {"k": "NServiceBus.ContentType", "v": "application/json"}, {"k": "NServiceBus.EnclosedMessageTypes", "v": "NServiceBus.AcceptanceTests.Outbox.When_a_duplicate_message_arrives+SendOrderAcknowledgement, NServiceBus.Storage.MongoDB.AcceptanceTests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"}, {"k": "NServiceBus.Version", "v": "10.0.0"}, {"k": "NServiceBus.TimeSent", "v": "2025-08-22 11:57:34:854985 Z"}]}]
```