### PR TITLE
Replace settings.Get

### DIFF
--- a/src/NServiceBus.Storage.MongoDB/Outbox/OutboxInstaller.cs
+++ b/src/NServiceBus.Storage.MongoDB/Outbox/OutboxInstaller.cs
@@ -15,8 +15,8 @@ sealed class OutboxInstaller(IReadOnlySettings settings, IServiceProvider servic
 {
     public async Task Install(string identity, CancellationToken cancellationToken = default)
     {
-        var installerSettings = settings.Get<InstallerSettings>();
-        if (installerSettings.Disabled || installerSettings.OutboxDisabled || !settings.IsFeatureActive(typeof(OutboxStorage)))
+        var installerSettings = settings.GetOrDefault<InstallerSettings>();
+        if (installerSettings == null || installerSettings.Disabled || installerSettings.OutboxDisabled || !settings.IsFeatureActive(typeof(OutboxStorage)))
         {
             return;
         }


### PR DESCRIPTION
If no settings are found for the installer, the Get method fails. To fix this issue, it has been replaced with GetOrDefault, and a null check has been added