### PR TITLE
Replace Mongo RegisterClassMap

### DIFF
--- a/src/NServiceBus.Storage.MongoDB/Outbox/OutboxStorage.cs
+++ b/src/NServiceBus.Storage.MongoDB/Outbox/OutboxStorage.cs
@@ -59,7 +59,7 @@ class OutboxStorage : Feature
         var usesDefaultClassMap = true;
         if (!BsonClassMap.IsClassMapRegistered(typeof(OutboxRecordId)))
         {
-            BsonClassMap.RegisterClassMap<OutboxRecordId>(cm =>
+            BsonClassMap.TryRegisterClassMap<OutboxRecordId>(cm =>
             {
                 cm.AutoMap();
                 cm.MapMember(x => x.PartitionKey).SetElementName("pk");
@@ -73,7 +73,7 @@ class OutboxStorage : Feature
 
         if (!BsonClassMap.IsClassMapRegistered(typeof(OutboxRecord)))
         {
-            BsonClassMap.RegisterClassMap<OutboxRecord>(cm =>
+            BsonClassMap.TryRegisterClassMap<OutboxRecord>(cm =>
             {
                 cm.AutoMap();
                 cm.MapIdMember(x => x.Id).SetSerializer(new OutboxRecordIdSerializer());
@@ -86,7 +86,7 @@ class OutboxStorage : Feature
 
         if (!BsonClassMap.IsClassMapRegistered(typeof(StorageTransportOperation)))
         {
-            BsonClassMap.RegisterClassMap<StorageTransportOperation>(cm =>
+            BsonClassMap.TryRegisterClassMap<StorageTransportOperation>(cm =>
             {
                 cm.AutoMap();
                 cm.MapMember(c => c.Headers)

--- a/src/NServiceBus.Storage.MongoDB/Sagas/SagaStorage.cs
+++ b/src/NServiceBus.Storage.MongoDB/Sagas/SagaStorage.cs
@@ -1,6 +1,8 @@
 ﻿namespace NServiceBus.Storage.MongoDB;
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using Features;
 using global::MongoDB.Bson.Serialization;
 using Microsoft.Extensions.DependencyInjection;
@@ -50,11 +52,7 @@ class SagaStorage : Feature
             var usesDefaultClassMap = false;
             if (!BsonClassMap.IsClassMapRegistered(sagaMetadata.SagaEntityType))
             {
-                var classMap = new BsonClassMap(sagaMetadata.SagaEntityType);
-                classMap.AutoMap();
-                classMap.SetIgnoreExtraElements(true);
-
-                BsonClassMap.RegisterClassMap(classMap);
+                RegisterSagaBsonClassMap(sagaMetadata);
 
                 usesDefaultClassMap = true;
             }
@@ -67,5 +65,19 @@ class SagaStorage : Feature
             }
         }
         return sagaEntityToClassMapDiagnostics;
+    }
+
+    static void RegisterSagaBsonClassMap(SagaMetadata sagaMetadata)
+    {
+        var genericClassMapType = typeof(BsonClassMap<>).MakeGenericType(sagaMetadata.SagaEntityType);
+        var classMap = Activator.CreateInstance(genericClassMapType) as BsonClassMap;
+        classMap.AutoMap();
+        classMap.SetIgnoreExtraElements(true);
+        var tryRegisterClassMapNonGeneric = typeof(BsonClassMap).GetMethods()
+            .Where(x => x is { Name: "TryRegisterClassMap", IsGenericMethodDefinition: true })
+            .Single(m =>
+                m.GetParameters().FirstOrDefault()?.ParameterType.ToString() == typeof(BsonClassMap<>).ToString());
+        var tryRegisterClassMapGeneric = tryRegisterClassMapNonGeneric!.MakeGenericMethod(sagaMetadata.SagaEntityType);
+        tryRegisterClassMapGeneric.Invoke(null, [classMap]);
     }
 }

--- a/src/NServiceBus.Storage.MongoDB/Sagas/SagaStorage.cs
+++ b/src/NServiceBus.Storage.MongoDB/Sagas/SagaStorage.cs
@@ -70,7 +70,10 @@ class SagaStorage : Feature
     static void RegisterSagaBsonClassMap(SagaMetadata sagaMetadata)
     {
         var genericClassMapType = typeof(BsonClassMap<>).MakeGenericType(sagaMetadata.SagaEntityType);
-        var classMap = Activator.CreateInstance(genericClassMapType) as BsonClassMap;
+        if (Activator.CreateInstance(genericClassMapType) is not BsonClassMap classMap)
+        {
+            return;
+        }
         classMap.AutoMap();
         classMap.SetIgnoreExtraElements(true);
         var tryRegisterClassMapNonGeneric = typeof(BsonClassMap).GetMethods()


### PR DESCRIPTION
When the parallel integration test is executed, the RegisterClassMap method throws an error because it attempts to register multiple times simultaneously during the test.