### PR TITLE
Exit installer if no settings configured

### DIFF
--- a/src/NServiceBus.Storage.MongoDB/Outbox/OutboxInstaller.cs
+++ b/src/NServiceBus.Storage.MongoDB/Outbox/OutboxInstaller.cs
@@ -15,8 +15,8 @@ sealed class OutboxInstaller(IReadOnlySettings settings, IServiceProvider servic
 {
     public async Task Install(string identity, CancellationToken cancellationToken = default)
     {
-        var installerSettings = settings.Get<InstallerSettings>();
-        if (installerSettings.Disabled || installerSettings.OutboxDisabled || !settings.IsFeatureActive(typeof(OutboxStorage)))
+        var installerSettings = settings.GetOrDefault<InstallerSettings>();
+        if (installerSettings is null || installerSettings.Disabled || installerSettings.OutboxDisabled || !settings.IsFeatureActive(typeof(OutboxStorage)))
         {
             return;
         }

--- a/src/NServiceBus.Storage.MongoDB/Sagas/SagaInstaller.cs
+++ b/src/NServiceBus.Storage.MongoDB/Sagas/SagaInstaller.cs
@@ -15,8 +15,8 @@ sealed class SagaInstaller(IReadOnlySettings settings, IServiceProvider serviceP
 {
     public async Task Install(string identity, CancellationToken cancellationToken = default)
     {
-        var installerSettings = settings.Get<InstallerSettings>();
-        if (installerSettings.Disabled || !settings.IsFeatureActive(typeof(SagaStorage)))
+        var installerSettings = settings.GetOrDefault<InstallerSettings>();
+        if (installerSettings is null || installerSettings.Disabled || !settings.IsFeatureActive(typeof(SagaStorage)))
         {
             return;
         }

--- a/src/NServiceBus.Storage.MongoDB/Subscriptions/SubscriptionInstaller.cs
+++ b/src/NServiceBus.Storage.MongoDB/Subscriptions/SubscriptionInstaller.cs
@@ -13,8 +13,8 @@ sealed class SubscriptionInstaller(IReadOnlySettings settings, IServiceProvider 
 {
     public async Task Install(string identity, CancellationToken cancellationToken = default)
     {
-        var installerSettings = settings.Get<InstallerSettings>();
-        if (installerSettings.Disabled || !settings.IsFeatureActive(typeof(SubscriptionStorage)))
+        var installerSettings = settings.GetOrDefault<InstallerSettings>();
+        if (installerSettings is null || installerSettings.Disabled || !settings.IsFeatureActive(typeof(SubscriptionStorage)))
         {
             return;
         }


### PR DESCRIPTION
- Fix for https://github.com/Particular/NServiceBus.Storage.MongoDB/issues/835
- Bug was only present in version 6.0, fixed in 7.0 because installers are not automatically loaded from scanned assemblies.