### PR TITLE
Pin transitive dependency Snappier to avoid CVE on release-6.0

### DIFF
--- a/src/NServiceBus.Storage.MongoDB/NServiceBus.Storage.MongoDB.csproj
+++ b/src/NServiceBus.Storage.MongoDB/NServiceBus.Storage.MongoDB.csproj
@@ -12,6 +12,11 @@
     <PackageReference Include="Particular.Packaging" Version="4.5.0" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup Label="Direct references to transitive dependencies to avoid versions with CVE">
+    <!-- Snappier is brought in by MongoDB.Driver - this reference can be removed when MongoDB.Driver is updated to reference latest version of Snappier -->
+    <PackageReference Include="Snappier" Version="1.3.1" />
+  </ItemGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="NServiceBus.Storage.MongoDB.PersistenceTests" />
     <InternalsVisibleTo Include="NServiceBus.Storage.MongoDB.Tests" />


### PR DESCRIPTION
Fixes:
- https://github.com/particular/NServiceBus.Storage.MongoDB/issues/931