### PR TITLE
Pin transitive dependency SharpCompress to avoid CVE on release-6.0

### DIFF
--- a/src/NServiceBus.Storage.MongoDB/NServiceBus.Storage.MongoDB.csproj
+++ b/src/NServiceBus.Storage.MongoDB/NServiceBus.Storage.MongoDB.csproj
@@ -13,7 +13,9 @@
   </ItemGroup>
 
   <ItemGroup Label="Direct references to transitive dependencies to avoid versions with CVE">
-    <!-- Snappier is brought in by MongoDB.Driver - this reference can be removed when MongoDB.Driver is updated to reference latest version of Snappier -->
+    <!-- Both Snappier and SharpCompress are brought in by MongoDB.Driver -->
+    <!-- These references can be removed when MongoDB.Driver is updated to reference the latest versions of Snappier and SharpCompress -->
+    <PackageReference Include="SharpCompress" Version="0.48.0" />
     <PackageReference Include="Snappier" Version="1.3.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes:
- #944 